### PR TITLE
chore(ci): add build workflow and no-relink check

### DIFF
--- a/.github/scripts/check_no_relink.sh
+++ b/.github/scripts/check_no_relink.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eu
+
+# Run make and capture output
+output=$(make 2>&1)
+echo "$output"
+
+# If make triggers any compiler call, we consider it a relink
+if echo "$output" | grep -qE "^\s*(c\+\+|g\+\+|clang\+\+)"; then
+	echo "ERROR: relinking detected (Makefile is not up-to-date-safe)"
+	exit 1
+fi
+
+echo "OK: no relinking detected on second make"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -6,7 +6,7 @@
 #    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2026/04/16 17:51:42 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/16 17:57:10 by jaubry--         ###   ########.fr        #
+#    Updated: 2026/04/16 18:23:24 by jaubry--         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -32,7 +32,7 @@ jobs:
         run: make
 
       - name: Check no relinking
-        run: ./scripts/check_no_relink.sh
+        run: ./github/scripts/check_no_relink.sh
 
       - name: Clean build
         run: make fclean && make

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -6,7 +6,7 @@
 #    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2026/04/16 17:51:42 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/16 18:23:24 by jaubry--         ###   ########.fr        #
+#    Updated: 2026/04/16 18:29:14 by jaubry--         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -32,7 +32,7 @@ jobs:
         run: make
 
       - name: Check no relinking
-        run: ./github/scripts/check_no_relink.sh
+        run: ./.github/scripts/check_no_relink.sh
 
       - name: Clean build
         run: make fclean && make

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,38 @@
+# **************************************************************************** #
+#                                                                              #
+#                                                         :::      ::::::::    #
+#    ci-build.yml                                       :+:      :+:    :+:    #
+#                                                     +:+ +:+         +:+      #
+#    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
+#                                                 +#+#+#+#+#+   +#+            #
+#    Created: 2026/04/16 17:51:42 by jaubry--          #+#    #+#              #
+#    Updated: 2026/04/16 17:57:10 by jaubry--         ###   ########.fr        #
+#                                                                              #
+# **************************************************************************** #
+
+name: CI - BUILD
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build
+        run: make
+
+      - name: Check no relinking
+        run: ./scripts/check_no_relink.sh
+
+      - name: Clean build
+        run: make fclean && make


### PR DESCRIPTION
## Summary
Set up the initial CI build workflow and add a script to detect unnecessary relinking in the Makefile.

## Why
We want to ensure that:
- the project always builds with the required C++98 flags,
- the Makefile does not relink when nothing has changed,
- a clean rebuild (`make fclean && make`) works in CI, not only locally.

This aligns with the engineering guidelines for keeping `main` always buildable and avoiding hidden Makefile issues.

## Changes
- Added `.github/workflows/ci-build.yml`:
  - Runs `make` on push and pull requests to `main`.
  - Runs a second `make` and fails if relinking is detected.
  - Runs `make fclean && make` to verify a clean rebuild.
- Added `scripts/check_no_relink.sh`:
  - Captures the output of a second `make`.
  - Fails if any compiler invocation (`c++`, `g++`, `clang++`) is detected.
  - Can also be run locally by developers.

## Tests
- [x] CI build passes on this branch.
- [x] `./scripts/check_no_relink.sh` succeeds locally on an up-to-date tree.
- [x] `./scripts/check_no_relink.sh` fails if the Makefile triggers a relink on a second `make`.

## Risks
- If the regex in the script is too strict or the Makefile is noisy, we might get false positives for relinking.
- Any future change to the build command (e.g. different compiler name) must be reflected in the script.

## Linked issue
Closes #2