### PR TITLE
chore(ci): add cppcheck static analysis

### DIFF
--- a/.github/scripts/run_cppcheck.sh
+++ b/.github/scripts/run_cppcheck.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu
+
+
+# Build a list of -I paths for include/ and all its subdirectories
+INCLUDE_DIR="include"
+INCLUDE_FLAGS=""
+
+if [ -d "$INCLUDE_DIR" ]; then
+  # Add all subdirectories under include/
+  while IFS= read -r dir; do
+    INCLUDE_FLAGS="${INCLUDE_FLAGS} -I ${dir}"
+  done < <(find "${INCLUDE_DIR}" -type d)
+fi
+
+echo "Using include flags: ${INCLUDE_FLAGS}"
+
+cppcheck \
+	--enable=all \
+	--std=c++98 \
+	--language=c++ \
+	--inline-suppr \
+	--error-exitcode=1 \
+	--suppress=missingIncludeSystem \
+	${INCLUDE_FLAGS} \
+	src

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,35 @@
+# **************************************************************************** #
+#                                                                              #
+#                                                         :::      ::::::::    #
+#    cppcheck.yml                                       :+:      :+:    :+:    #
+#                                                     +:+ +:+         +:+      #
+#    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
+#                                                 +#+#+#+#+#+   +#+            #
+#    Created: 2026/04/16 18:40:05 by jaubry--          #+#    #+#              #
+#    Updated: 2026/04/16 18:41:38 by jaubry--         ###   ########.fr        #
+#                                                                              #
+# **************************************************************************** #
+
+name: CI - cppcheck
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install cppcheck
+        run: sudo apt-get update && sudo apt-get install -y cppcheck
+
+      - name: Run cppcheck
+        run: ./.github/scripts/run_cppcheck.sh


### PR DESCRIPTION
## Summary
Add a cppcheck static analysis job to the CI pipeline, with a script that can also be used locally by developers.

## Why
We want every pull request to be blocked if cppcheck finds any relevant issue (style, performance, or more severe), so that code quality stays high from the very beginning of the project.

## Changes
- Added `.github/workflows/cppcheck.yml`:
  - Runs on push and pull requests targeting `main`.
  - Checks out the repository (including submodules).
  - Installs `cppcheck` on the CI runner.
  - Delegates the actual analysis to `scripts/run_cppcheck.sh`.
- Added `scripts/run_cppcheck.sh`:
  - Builds include flags dynamically for `include/` and all its subdirectories.
  - Runs `cppcheck` with:
    - `--enable=all`
    - `--std=c++98`
    - `--language=c++`
    - `--inline-suppr`
    - `--error-exitcode=1`
    - `-I` flags for `include/` and subdirectories
    - analysis root `src`
  - Can be run locally by developers before pushing.

## Tests
- [x] CI cppcheck job passes on this branch.
- [x] `./scripts/run_cppcheck.sh` succeeds locally on the current main.
- [x] Introducing a deliberate cppcheck warning locally causes the script and CI job to fail.

## Risks
- If we restructure `include/` or `src/`, the script paths must be kept in sync.
- Inline suppressions (`// cppcheck-suppress <id>`) must be justified in code to avoid hiding real issues.

## Linked issue
Closes #3