### PR TITLE
Chore/6 codeowners and core documentation files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# CODEOWNERS for ft_IRC
+
+# Github repository configuration and actions
+/.github/			@eterrale @ketodin
+
+# Documentation
+/docs/adr/			@lcalero42
+
+# Build system and make includes
+/Makefile			@ketodin
+/includes.mk		@ketodin
+/mkdir/				@ketodin
+.gitmodules			@ketodin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to `ircserv` will be documented here.  
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).  
+Versioning follows [Semantic Versioning](https://semver.org/).
+
+---
+
+## [Unreleased]
+
+### Added
+- Repository bootstrap: `.github/`, `docs/`, `src/`, `include/` directory structure
+- Engineering guidelines (`docs/engineering-guidelines.md`)
+- Architecture overview stub (`docs/architecture.md`)
+- Runbook stub (`docs/runbook.md`)
+- This changelog

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,47 @@
+# Architecture
+
+> **Status:** stub — to be expanded as the codebase stabilises.
+
+## Overview
+
+`ircserv` is a single-process, non-blocking IRC server written in C++98.  
+It handles all I/O through a single `poll()` call (or equivalent) and supports multiple simultaneous clients without forking.
+
+## Directory Structure
+
+```sh
+src/
+network/    # socket creation, bind/listen/accept, poll event loop
+core/       # Server, ClientManager, ChannelManager, command dispatch
+parser/     # IRCParser – line reassembly from partial recv(), message tokenisation
+commands/   # One handler per IRC command (JOIN, PART, PRIVMSG, MODE, KICK, …)
+auth/       # Registration state machine, operator vs. regular user
+include/    # Public headers
+docs/       # Documentation
+```
+
+## Key Design Decisions
+
+See `docs/adr/` for Architecture Decision Records. Initial ADRs planned:
+
+- `0001-single-poll-event-loop.md` – why a single `poll()` loop
+- `0002-per-client-recv-buffer.md` – per-client buffer for partial message reassembly
+- `0003-command-dispatch-map.md` – command dispatch approach
+
+## Component Responsibilities
+
+| Component | Responsibility |
+|---|---|
+| `Network` | Non-blocking sockets, `poll` loop, accept new clients |
+| `Server` | Global state, client/channel lists, event dispatch |
+| `Parser` | Reconstruct IRC lines from partial `recv()`, extract command + params |
+| `Commands` | One handler per IRC command; validates preconditions, sends RFC replies |
+| `Auth/Modes` | Registration state (PASS → NICK → USER), operator flags, channel modes |
+
+## IRC Compliance
+
+- TCP/IP v4 (or v6)
+- Supported commands: `PASS`, `NICK`, `USER`, `JOIN`, `PART`, `PRIVMSG`, `NOTICE`, `QUIT`, `PING`/`PONG`, `KICK`, `INVITE`, `TOPIC`, `MODE`
+- Supported channel modes: `i`, `t`, `k`, `o`, `l`
+- Reference client: _to be documented (e.g. HexChat / irssi / WeeChat)_
+

--- a/docs/engineering-guidelines.md
+++ b/docs/engineering-guidelines.md
@@ -1,0 +1,24 @@
+# Engineering Guidelines
+
+> This file is a pointer to the main workflow document.
+> All engineering guidelines for **ftirc** are maintained in [`IRC-workflow.md`](./IRC-workflow.md).
+
+## Quick Reference
+
+| Topic | Section in IRC-workflow.md |
+|---|---|
+| Git branching strategy | §3 – Organisation Git |
+| Commit conventions | §4 – Convention de commits |
+| Code standards (C++98) | §5 – Norme d'écriture du code |
+| Pull Request rules | §6 – Pull Requests |
+| Code review guidelines | §7 – Code Review |
+| Issue management | §8 – Issues et gestion du travail |
+| CI / GitHub Actions | §9 – CI avec GitHub Actions |
+| Build & environment | §10 – Build et environnement |
+| IRC commands & modes | §11 – Comportement IRC |
+| Network / IO | §12 – Gestion du réseau et IO |
+| Tests | §13 – Tests |
+| Security | §14 – Sécurité minimale |
+| Documentation requirements | §15 – Documentation obligatoire |
+| Definition of Done | §17 – Definition of Done |
+

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,90 @@
+# Runbook
+
+> Operational procedures for building, running, testing, and debugging `ircserv`.
+
+## Build
+
+#### Full build
+```bash
+make
+```
+
+#### Clean rebuild
+```bash
+make re
+```
+
+#### Remove objects only
+```bash
+make clean
+```
+
+#### Remove objects + binary
+```bash
+make fclean
+```
+
+Compilation flags: `-Wall -Wextra -Werror -std=c++98`
+No external libraries or Boost allowed.
+
+## Run
+
+```bash
+./ircserv <port> <password>
+
+# Example
+./ircserv 6667 mysecretpassword
+```
+
+## Connect for Manual Testing
+
+With `nc` (partial data fragmentation test)
+```bash
+nc -C 127.0.0.1 6667
+# Then type commands, use Ctrl+D to send in parts:
+# com -> man -> d\r\n
+```
+
+With reference IRC client (HexChat)
+```text
+Server:     127.0.0.1
+Port:       6667
+Password:   <your password>
+```
+
+> The chosen reference client must be documented here once decided.
+
+## Run with Valgrind or Sanitizer
+
+\[...\]
+
+## Debugging a Network Bug
+
+1. Check `poll()` return value and `revents` flags.
+
+2. Verify the client fd is still valid (handle `recv()` returning `0` or `-1/ECONNRESET`).
+
+3. Confirm the per-client buffer is being accumulated correctly for partial messages.
+
+4. Reproduce with `nc -C` fragmentation test.
+
+## Server Crash During Evaluation
+
+1. `make re` to do a clean rebuild.
+
+2. Run under `valgrind` to identify the fault.
+
+3. Check for uninitialised reads, double-free, or use-after-close on a socket fd.
+
+## Recreate a Clean Environment
+
+```bash
+make fclean
+make
+./ircserv 6667 password
+```
+
+## Reproducible Test Scripts
+
+> Test scripts will be documented here as they are written.
+> All scripts must be runnable from the repo root and referenced in this file.


### PR DESCRIPTION
## Summary
Add the four stub documentation files required by the engineering guidelines.

## Why
The engineering guidelines mandate a minimal set of documentation files from the start of the project. This PR satisfies Issue #6 by creating all required stubs so the `docs/` structure is in place for future expansion. Adds a `CODEOWNERS` file inside `.github/`

## Changes
- Add `docs/engineering-guidelines.md` — points to `IRC-workflow.md` as the source of truth
- Add `docs/architecture.md` — stub with module breakdown and directory structure
- Add `docs/runbook.md` — stub with build, run, test, and debug procedures
- Add `CHANGELOG.md` — stub following Keep a Changelog format, single `[Unreleased]` section
- Add `.github/CODEOWNERS` — stub with basic roles

## Risks
None. Pure documentation stubs, no source code touched.

## Linked issue
Closes #6

## Merge policy

- Use squash or rebase merges only (no merge commits).
- Ensure dependencies are merged and there's no `blocked` label
- Do not merge if any CI check is red.
- Do not merge without at least one review approval.
- Ensure the branch is up to date with main before merging.