### PR TITLE
Chore/7 setup clang format and editorconfig

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,131 @@
+# --- ft_irc | clang-format 14.0.0 ---
+---
+Language:       Cpp          # Apply these rules to C++ files
+Standard:       Cpp03        # Parse code as C++03 (= C++98 compatible)
+BasedOnStyle:   GNU          # Start from GNU defaults, override below
+
+
+
+# --- Indentation ---
+IndentWidth:             4   # Each indent level = 4 spaces
+TabWidth:                4   # A tab character = 4 columns wide (used in calculations)
+UseTab:                  Always        # Always emits real tabs
+ContinuationIndentWidth: 4   # Wrapped lines are indented 4 spaces from their parent
+IndentCaseLabels:        true # 'case' and 'default' are indented inside 'switch' blocks
+IndentPPDirectives:      AfterHash    # Indents preprocessor directives based on #if/#ifdef depth
+                                      # '#' stays at col 0, directive keyword is indented after it
+                                      # e.g.: #  define MY_MACRO inside a nested #ifdef block
+IndentAccessModifiers:   true
+
+# --- Line length ---
+ColumnLimit:        80      # Lines longer than 120 chars will be wrapped
+
+
+
+# --- Braces ---
+BreakBeforeBraces: Allman    # Opening '{' always goes on its own line (Allman style)
+
+
+
+# --- Parameters & arguments ---
+BinPackParameters: false     # When params overflow, each goes on its own line (no cramming)
+BinPackArguments:  false     # Same rule at call sites for arguments
+
+
+
+# --- Constructor initializer list ---
+BreakConstructorInitializers: AfterColon  # ':' starts on a new line before member list
+                                           # Foo() \n : member(val), other(val)
+PackConstructorInitializers: Never  # forces one initializer per line always, even if they'd fit on one line.
+                                     # Without this, clang-format still collapses them when they fit within 120 cols
+
+
+
+# --- Const placement ---
+SortIncludes: true
+QualifierAlignment: Left     # Left' = west const (const std::string &)
+#QualifierOrder: [const, static, inline]
+
+
+# --- Spaces ---
+SpaceBeforeParens:              ControlStatements  # Space in if( for( while( — not in foo(
+SpaceBeforeAssignmentOperators: true               # a = b, not a=b
+SpacesInParentheses:            false              # (x) not ( x )
+SpacesInAngles:                 false              # <int> not < int >
+SpacesInSquareBrackets:         false              # arr[i] not arr[ i ]
+SpaceAfterCStyleCast:           false              # (int)x not (int) x
+SpaceAfterLogicalNot:           false
+SpaceAfterTemplateKeyword:      false
+
+# --- Pointers & References ---
+PointerAlignment: Left       # int* ptr and int& ref — star/ampersand attached to the type
+
+
+
+# --- Includes ---
+
+IncludeBlocks: Preserve      # Keeps existing #include groups separated by blank lines as-is
+                             # Does not merge or reorder groups
+
+
+
+# --- Empty lines ---
+SeparateDefinitionBlocks:          Always  # Blank line between each function/class/struct definition
+MaxEmptyLinesToKeep:               1       # Collapses multiple consecutive blank lines into one
+KeepEmptyLinesAtTheStartOfBlocks:  false   # Removes blank line immediately after opening '{'
+
+
+
+# --- Functions ---
+AllowShortFunctionsOnASingleLine:    None   # All functions must be multi-line, even int foo() { return 0; }
+AllowShortIfStatementsOnASingleLine: false  # if body always on its own line
+AllowShortLoopsOnASingleLine:        false  # for/while body always on its own line
+
+
+
+# --- Alignment ---
+#AlignConsecutiveAssignments:  true  # Does NOT align '=' in consecutive assignments
+                                     # Avoids noisy diffs when one variable name changes
+#AlignConsecutiveDeclarations: true  # Does NOT align types/names in consecutive declarations
+                                     # Same reason — avoids full-block realignment noise
+AlignTrailingComments:        true   # Aligns '//' end-of-line comments vertically in a block
+
+AlignConsecutiveAssignments:
+    Enabled: true
+    AlignCompound: true
+    AlignFunctionDeclarations: true
+    PadOperators: true
+
+#AlignConsecutiveBitFields:
+#    Enabled: true
+#    AlignCompound: true
+#    AlignFunctionDeclarations: true
+#    PadOperators: true
+
+#AlignConsecutiveDeclarations:
+#    Enabled: true
+#    AcrossComments: true
+#    AlignCompound: true
+#    AlignFunctionDeclarations: true
+#    PadOperators: true
+
+#AlignConsecutiveMacros:
+#    Enabled: true
+#    AcrossComments: true
+#    AlignCompound: true
+#    AlignFunctionDeclarations: true
+#    PadOperators: true
+
+AlignArrayOfStructures: Left
+
+AlignConsecutiveAssignments: true
+
+
+# --- Misc ---
+Cpp11BracedListStyle:            false  # Keeps spaces inside { } initializer lists — correct for C++98
+AlwaysBreakTemplateDeclarations: true   # template <typename T> always on its own line
+BreakBeforeTernaryOperators:     true   # '?' and ':' go at the start of new lines, not end of previous
+BreakBeforeBinaryOperators:      NonAssignment  # '<<', '+', '-' etc. go at start of new line when wrapping
+                                                # Assignment operators '=', '+=' stay at end of line
+AlignOperands:                   Align  # When a binary expression wraps, operands align vertically
+                                        # under the first operand

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+root = true  # Stop searching parent directories for more .editorconfig files
+             # This file is the single source of truth for the whole repo
+
+
+# Defaults for all files
+[*]
+charset = utf-8                  # All files saved as UTF-8 — prevents Latin-1 or UTF-16 from editors
+end_of_line = lf                 # Unix line endings (\n) — prevents Windows CRLF (\r\n) in commits
+trim_trailing_whitespace = true  # Removes invisible spaces/tabs at end of lines on save
+insert_final_newline = true      # Every file ends with a newline — POSIX standard, avoids git diff noise
+indent_style = tab   # Uses real tab chars
+                     # UseTab: Never in .clang-format, otherwise every file fails CI immediately
+indent_size = 4      # Logical indent unit = 4
+tab_width = 4        # Tab renders as 4 columns wide in the editor UI
+
+
+# C and C++ source and header files
+[*.{c,cc,cpp,cxx,h,hpp,hxx,tpp,ipp}, Makefile]
+indent_style = tab   # Uses real tab chars
+                     # UseTab: Never in .clang-format, otherwise every file fails CI immediately
+indent_size = 4      # Logical indent unit = 4
+tab_width = 4        # Tab renders as 4 columns wide in the editor UI
+
+
+# YAML (CI workflows, GitHub Actions)
+[*.{yml,yaml}]
+indent_style = space  # YAML forbids tabs — spaces only
+indent_size = 4       # Standard YAML indent (GitHub Actions, Docker Compose etc.)
+
+
+# Markdown documentation
+[*.md]
+trim_trailing_whitespace = false  # Exception to the global rule — two trailing spaces
+                                  # in Markdown = intentional <br> line break, must be preserved

--- a/docs/engineering-guidelines.md
+++ b/docs/engineering-guidelines.md
@@ -1,24 +1,43 @@
 # Engineering Guidelines
 
-> This file is a pointer to the main workflow document.
-> All engineering guidelines for **ftirc** are maintained in [`IRC-workflow.md`](./IRC-workflow.md).
+> This document briefly describes the two formatting configuration files committed to the repository.
+> All engineering guidelines for **ft_irc** are maintained in [`IRC-workflow.md`](./docs/IRC-workflow.md).
 
-## Quick Reference
+---
 
-| Topic | Section in IRC-workflow.md |
-|---|---|
-| Git branching strategy | §3 – Organisation Git |
-| Commit conventions | §4 – Convention de commits |
-| Code standards (C++98) | §5 – Norme d'écriture du code |
-| Pull Request rules | §6 – Pull Requests |
-| Code review guidelines | §7 – Code Review |
-| Issue management | §8 – Issues et gestion du travail |
-| CI / GitHub Actions | §9 – CI avec GitHub Actions |
-| Build & environment | §10 – Build et environnement |
-| IRC commands & modes | §11 – Comportement IRC |
-| Network / IO | §12 – Gestion du réseau et IO |
-| Tests | §13 – Tests |
-| Security | §14 – Sécurité minimale |
-| Documentation requirements | §15 – Documentation obligatoire |
-| Definition of Done | §17 – Definition of Done |
+## `.clang-format`
 
+A `.clang-format` file configured for **clang-format 14.0.0** is committed at the root of the repository.
+It enforces a consistent C++ code style across all contributors automatically.
+
+Key rules at a glance:
+
+- **Standard**: C++03 / C++98 compatible (`Standard: Cpp03`)
+- **Base style**: GNU, with overrides
+- **Indentation**: 4-wide real tabs (`UseTab: Always`, `IndentWidth: 4`)
+- **Line length**: 80 columns (`ColumnLimit: 80`)
+- **Braces**: Allman style — opening `{` always on its own line
+- **Parameters / arguments**: one per line when overflowing, no bin-packing
+- **Pointer alignment**: left — `int* ptr`, `int& ref`
+- **Short constructs**: no short functions, `if`, or loops on a single line
+- **Spaces**: before control statement parens (`if (`, `for (`), not before function calls
+
+> For the full CI lint job that checks formatting on every PR, see [§9 – CI with GitHub Actions](./docs/IRC-workflow.md#9-ci-avec-github-actions).
+
+---
+
+## `.editorconfig`
+
+An `.editorconfig` file is committed at the root of the repository (`root = true`).
+It is the single source of truth for editor-level formatting and applies to all contributors regardless of their IDE or editor.
+
+Rules per file type:
+
+| File type | Indent style | Indent size | Notes |
+|---|---|---|---|
+| All files (default) | Tab | 4 | UTF-8, LF line endings, trim trailing whitespace, final newline |
+| `*.{c,cc,cpp,h,hpp,...}`, `Makefile` | Tab | 4 | Matches `.clang-format` tab settings |
+| `*.{yml,yaml}` | Space | 4 | YAML forbids tabs |
+| `*.md` | Tab | 4 | Trailing whitespace **preserved** (two spaces = intentional `<br>`) |
+
+> Code style expectations and formatting requirements are detailed in [§5 – Code Standards](./docs/IRC-workflow.md#5-norme-décriture-du-code).


### PR DESCRIPTION
## Summary
Add `.clang-format` and `.editorconfig` configuration files at the root of the repository, and document them briefly in `docs/engineering-guidelines.md`.

## Why
The workflow requires agreeing on a common style from day one and committing a shared `.clang-format` if available. Both files ensure every contributor formats code identically regardless of their editor or IDE, and they serve as the reference for the CI lint job.

## Changes
- Add `.clang-format` configured for clang-format 14, C++98/C++03, Allman braces, 80-column limit, real tabs (4-wide)
- Add `.editorconfig` as single source of truth for editor-level formatting (UTF-8, LF, 4-wide tabs, per-filetype overrides for YAML and Markdown)
- Add `docs/engineering-guidelines.md` documenting both files with a redirect to `IRC-workflow.md`

## Risks
Low risk — these files are tooling only and do not affect compilation or runtime behaviour. However, contributors who run `clang-format` on existing code before alignment is agreed upon may produce large noisy diffs. Apply formatting incrementally and per-file.

## Linked issue
Closes #7

---

## Merge policy

- Use squash or rebase merges only (no merge commits).
- Ensure dependencies are merged and there's no `blocked` label.
- Do not merge if any CI check is red.
- Do not merge without at least one review approval.
- Ensure the branch is up to date with main before merging.