### PR TITLE
chore/27 Add auto-label workflows for issues and PRs

### DIFF
--- a/.github/scripts/copy-labels-from-issue.js
+++ b/.github/scripts/copy-labels-from-issue.js
@@ -1,0 +1,25 @@
+// Usage: called by actions/github-script with { github, context } injected
+module.exports = async ({ github, context }) => {
+  const body = context.payload.pull_request.body || '';
+  const issueMatch = body.match(/(?:closes|fixes|resolves):?\s+#(\d+)/i);
+  if (!issueMatch) return;
+
+  const issueNumber = parseInt(issueMatch[1]);
+
+  const { data: issueLabels } = await github.rest.issues.listLabelsOnIssue({
+    ...context.repo,
+    issue_number: issueNumber,
+  });
+
+  const toCopy = issueLabels
+    .map(l => l.name)
+    .filter(n => n.startsWith('type:') || n.startsWith('priority:'));
+
+  if (toCopy.length === 0) return;
+
+  await github.rest.issues.addLabels({
+    ...context.repo,
+    issue_number: context.payload.pull_request.number,
+    labels: toCopy,
+  });
+}

--- a/.github/scripts/label-issue.js
+++ b/.github/scripts/label-issue.js
@@ -1,0 +1,41 @@
+// Usage: called by actions/github-script with { github, context } injected
+module.exports = async ({ github, context }) => {
+  const title = context.payload.issue.title;
+  const match = title.match(/^\[([A-Z]+)\]/);
+  if (!match) return;
+
+  const typeMap = {
+    TASK:     'type:task',
+    FIX:      'type:fix',
+    REFACTOR: 'type:refactor',
+    STYLE:    'type:style',
+    DOCS:     'type:docs',
+    TEST:     'type:test',
+    CHORE:    'type:chore',
+    PERF:     'type:perf',
+  };
+
+  const label = typeMap[match[1].toUpperCase()];
+  if (!label) return;
+
+  const { data: current } = await github.rest.issues.listLabelsOnIssue({
+    ...context.repo,
+    issue_number: context.issue.number,
+  });
+
+  for (const l of current) {
+    if (l.name.startsWith('type:') && l.name !== label) {
+      await github.rest.issues.removeLabel({
+        ...context.repo,
+        issue_number: context.issue.number,
+        name: l.name,
+      }).catch(() => {});
+    }
+  }
+
+  await github.rest.issues.addLabels({
+    ...context.repo,
+    issue_number: context.issue.number,
+    labels: [label],
+  });
+};

--- a/.github/scripts/label-pr-from-title.js
+++ b/.github/scripts/label-pr-from-title.js
@@ -1,0 +1,41 @@
+// Usage: called by actions/github-script with { github, context } injected
+module.exports = async ({ github, context }) => {
+  const title = context.payload.pull_request.title;
+  const match = title.match(/^([a-z]+)\//i);
+  if (!match) return;
+
+  const typeMap = {
+    task:     'type:task',
+    fix:      'type:fix',
+    refactor: 'type:refactor',
+    style:    'type:style',
+    docs:     'type:docs',
+    test:     'type:test',
+    chore:    'type:chore',
+    perf:     'type:perf',
+  };
+
+  const label = typeMap[match[1].toLowerCase()];
+  if (!label) return;
+
+  const { data: current } = await github.rest.issues.listLabelsOnIssue({
+    ...context.repo,
+    issue_number: context.payload.pull_request.number,
+  });
+
+  for (const l of current) {
+    if (l.name.startsWith('type:') && l.name !== label) {
+      await github.rest.issues.removeLabel({
+        ...context.repo,
+        issue_number: context.payload.pull_request.number,
+        name: l.name,
+      }).catch(() => {});
+    }
+  }
+
+  await github.rest.issues.addLabels({
+    ...context.repo,
+    issue_number: context.payload.pull_request.number,
+    labels: [label],
+  });
+};

--- a/.github/workflows/label-issues.yaml
+++ b/.github/workflows/label-issues.yaml
@@ -1,0 +1,20 @@
+name: Auto-label issues from title
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apply type label from title prefix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fn = require('./.github/scripts/label-issue.js');
+            await fn({ github, context });

--- a/.github/workflows/label-pr.yaml
+++ b/.github/workflows/label-pr.yaml
@@ -1,0 +1,28 @@
+name: Auto-label PRs from title and linked issue
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apply type label from PR title prefix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fn = require('./.github/scripts/label-pr-from-title.js');
+            await fn({ github, context });
+
+      - name: Copy type and priority labels from linked issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fn = require('./.github/scripts/copy-labels-from-issue.js');
+            await fn({ github, context });


### PR DESCRIPTION
## Summary
Adds two GitHub Actions workflows and their supporting scripts to automatically apply `type:*` labels on issues and PRs based on their title prefix, and copy `type:*` / `priority:*` labels from a linked issue onto the PR when it is opened.

## Why
Issues and PRs follow the `[TYPE]` / `type/issue-slug` naming conventions defined in the workflow cheatsheet but labels were being set manually. This automates the labeling step so the label state always reflects the title without human intervention.

## Changes
- Add `.github/workflows/label-issues.yaml` — triggers on issue opened/edited, parses `[TYPE]` prefix, applies matching `type:*` label and removes stale ones
- Add `.github/workflows/label-pr.yaml` — triggers on PR opened/edited, applies `type:*` from `type/` title prefix and copies `type:*` / `priority:*` from the linked issue
- Add `.github/scripts/label-issue.js` — script logic for issue labeling
- Add `.github/scripts/label-pr-from-title.js` — script logic for PR title labeling
- Add `.github/scripts/copy-labels-from-issue.js` — script logic for copying labels from linked issue via `Closes #N`

## Tests
- [ ] Opening an issue with `[CHORE] ...` applies `type:chore`
- [ ] Editing an issue title from `[CHORE]` to `[FIX]` swaps the label correctly
- [ ] Opening a PR titled `chore/27 ...` with `Closes #27` in body applies `type:chore` and copies `priority:*` from the issue

## Risks
- If a label referenced by the type map does not exist in the repo yet, the API call will return a 422 — all 8 `type:*` labels and `priority:*` labels must be created in the repo before merging.
- The copy step only fires on PR `opened`/`edited` — priority labels added to the issue after the PR is open won't propagate until the PR description is re-saved.

## Linked issue
Closes #27

***

## Merge policy

- Use squash or rebase merges only (no merge commits).
- Ensure dependancy are merged and there's no `blocked` label
- Do not merge if any CI check is red.
- Do not merge without at least one review approval.
- Ensure the branch is up to date with main before merging.