### PR TITLE
Chore/25 enhance check format sript

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,6 +17,8 @@ IndentPPDirectives:      AfterHash    # Indents preprocessor directives based on
                                       # e.g.: #  define MY_MACRO inside a nested #ifdef block
 IndentAccessModifiers:   true
 
+
+
 # --- Line length ---
 ColumnLimit:        80      # Lines longer than 120 chars will be wrapped
 
@@ -57,13 +59,14 @@ SpaceAfterCStyleCast:           false              # (int)x not (int) x
 SpaceAfterLogicalNot:           false
 SpaceAfterTemplateKeyword:      false
 
+
+
 # --- Pointers & References ---
 PointerAlignment: Left       # int* ptr and int& ref — star/ampersand attached to the type
 
 
 
 # --- Includes ---
-
 IncludeBlocks: Preserve      # Keeps existing #include groups separated by blank lines as-is
                              # Does not merge or reorder groups
 
@@ -84,9 +87,7 @@ AllowShortLoopsOnASingleLine:        false  # for/while body always on its own l
 
 
 # --- Alignment ---
-#AlignConsecutiveAssignments:  true  # Does NOT align '=' in consecutive assignments
-                                     # Avoids noisy diffs when one variable name changes
-#AlignConsecutiveDeclarations: true  # Does NOT align types/names in consecutive declarations
+AlignConsecutiveDeclarations: true  # Does NOT align types/names in consecutive declarations
                                      # Same reason — avoids full-block realignment noise
 AlignTrailingComments:        true   # Aligns '//' end-of-line comments vertically in a block
 
@@ -96,29 +97,9 @@ AlignConsecutiveAssignments:
     AlignFunctionDeclarations: true
     PadOperators: true
 
-#AlignConsecutiveBitFields:
-#    Enabled: true
-#    AlignCompound: true
-#    AlignFunctionDeclarations: true
-#    PadOperators: true
-
-#AlignConsecutiveDeclarations:
-#    Enabled: true
-#    AcrossComments: true
-#    AlignCompound: true
-#    AlignFunctionDeclarations: true
-#    PadOperators: true
-
-#AlignConsecutiveMacros:
-#    Enabled: true
-#    AcrossComments: true
-#    AlignCompound: true
-#    AlignFunctionDeclarations: true
-#    PadOperators: true
-
 AlignArrayOfStructures: Left
-
 AlignConsecutiveAssignments: true
+
 
 
 # --- Misc ---

--- a/.github/scripts/check_format.sh
+++ b/.github/scripts/check_format.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# scripts/check_format.sh
+# .github/scripts/check_format.sh
 
 # ── ANSI codes ────────────────────────────────────────────────────────────────
 RESET='\033[0m'
@@ -17,89 +17,172 @@ BG_DARK='\033[48;5;235m'
 SRC_DIRS=("src" "include")
 EXTENSIONS=("*.cpp" "*.hpp" "*.tpp" "*.ipp")
 
-# ── Build find arguments from config ─────────────────────────────────────────
+# ── Build find name filter from config ───────────────────────────────────────
 FIND_NAMES=()
 first=true
 for ext in "${EXTENSIONS[@]}"; do
-	if [ "$first" = true ]; then
-		first=false
-	else
-		FIND_NAMES+=("-o")
-	fi
-	FIND_NAMES+=("-name" "$ext")
+    if [ "$first" = true ]; then
+        first=false
+    else
+        FIND_NAMES+=("-o")
+    fi
+    FIND_NAMES+=("-name" "$ext")
 done
 
-FILES=$(find "${SRC_DIRS[@]}" -type f \( "${FIND_NAMES[@]}" \) 2>/dev/null)
-
-# ── Parse location from hunk header (original file line numbers only) ────────
-parse_location() {
-	local hunk="$1"
-	if [[ "$hunk" =~ ^([0-9]+),([0-9]+)[acd] ]]; then
-		echo "${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
-	elif [[ "$hunk" =~ ^([0-9]+)[acd] ]]; then
-		echo "${BASH_REMATCH[1]}"
-	fi
+# ── Usage ─────────────────────────────────────────────────────────────────────
+print_usage() {
+    echo -e "${BOLD}${WHITE}Usage:${RESET}"
+    echo -e "  ${DIM}$0 [--format] [--help] [file_or_dir ...]${RESET}"
+    echo ""
+    echo -e "${BOLD}${WHITE}Options:${RESET}"
+    echo -e "  ${GREEN}--format${RESET}      Show diff output, then run clang-format -i on all"
+    echo -e "                targeted files in place. Always exits 0."
+    echo -e "  ${GREEN}--help${RESET}        Show this help message and exit."
+    echo ""
+    echo -e "${BOLD}${WHITE}Arguments:${RESET}"
+    echo -e "  ${YELLOW}file_or_dir${RESET}   Any number of files or directories to check/format."
+    echo -e "                Directories are searched recursively for matching extensions."
+    echo -e "                If omitted, defaults to: ${DIM}${SRC_DIRS[*]}${RESET}"
+    echo ""
+    echo -e "${BOLD}${WHITE}Extensions checked:${RESET} ${DIM}${EXTENSIONS[*]}${RESET}"
+    echo ""
+    echo -e "${BOLD}${WHITE}Exit codes:${RESET}"
+    echo -e "  ${GREEN}0${RESET}  All files correctly formatted (or --format was used)"
+    echo -e "  ${RED}1${RESET}  One or more files are not correctly formatted"
+    echo -e "  ${RED}2${RESET}  Unknown flag"
+    echo ""
+    echo -e "${BOLD}${WHITE}Examples:${RESET}"
+    echo -e "  ${DIM}$0${RESET}                                  # check all files under src/ and include/"
+    echo -e "  ${DIM}$0 src/main.cpp${RESET}                     # check a single file"
+    echo -e "  ${DIM}$0 includes/core/${RESET}                   # check all files in a directory"
+    echo -e "  ${DIM}$0 src/main.cpp includes/core/${RESET}      # check a file + a directory"
+    echo -e "  ${DIM}$0 --format${RESET}                         # format all default files in place"
+    echo -e "  ${DIM}$0 --format src/main.cpp${RESET}            # format a single file in place"
+    echo -e "  ${DIM}$0 --format src/main.cpp includes/core/${RESET}"
 }
 
-# ── File header/footer ────────────────────────────────────────────────────────
+# ── Argument parsing ──────────────────────────────────────────────────────────
+FORMAT_MODE=false
+TARGETS=()
+
+for arg in "$@"; do
+    if [ "$arg" = "--help" ]; then
+        print_usage
+        exit 0
+    elif [ "$arg" = "--format" ]; then
+        FORMAT_MODE=true
+    elif [[ "$arg" == --* ]]; then
+        echo -e "${RED}${BOLD}Unknown flag: $arg${RESET}"
+        echo -e "${DIM}Run '$0 --help' for usage.${RESET}"
+        exit 2
+    else
+        TARGETS+=("$arg")
+    fi
+done
+
+# ── Collect files from targets or default SRC_DIRS ───────────────────────────
+FILES=""
+if [ ${#TARGETS[@]} -eq 0 ]; then
+    FILES=$(find "${SRC_DIRS[@]}" -type f \( "${FIND_NAMES[@]}" \) 2>/dev/null)
+else
+    for target in "${TARGETS[@]}"; do
+        if [ -f "$target" ]; then
+            FILES="$FILES"$'\n'"$target"
+        elif [ -d "$target" ]; then
+            FOUND=$(find "$target" -type f \( "${FIND_NAMES[@]}" \) 2>/dev/null)
+            FILES="$FILES"$'\n'"$FOUND"
+        else
+            echo -e "${YELLOW}${BOLD}Warning: '$target' is not a valid file or directory, skipping.${RESET}"
+        fi
+    done
+    FILES=$(echo "$FILES" | sed '/^$/d')
+fi
+
+# ── Parse location from hunk header (original file line numbers only) ─────────
+parse_location() {
+    local hunk="$1"
+    if [[ "$hunk" =~ ^([0-9]+),([0-9]+)[acd] ]]; then
+        echo "${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
+    elif [[ "$hunk" =~ ^([0-9]+)[acd] ]]; then
+        echo "${BASH_REMATCH[1]}"
+    fi
+}
+
+# ── File header ───────────────────────────────────────────────────────────────
 print_file_header() {
-	local file="$1"
-	local width=60
-	local label=" $file "
-	local label_len=${#label}
-	local fill=$(( (width - label_len) / 2 ))
-	local line=$(printf '═%.0s' $(seq 1 $fill))
-	local line_r=$(printf '═%.0s' $(seq 1 $(( width - fill - label_len )) ))
-	echo ""
-	echo -e "${RED}${BOLD}╔$(printf '═%.0s' $(seq 1 $width))╗${RESET}"
-	echo -e "${RED}${BOLD}║${WHITE}${line}${label}${line_r}${RED}${BOLD}║${RESET}"
-	echo -e "${RED}${BOLD}╚$(printf '═%.0s' $(seq 1 $width))╝${RESET}"
+    local file="$1"
+    local width=60
+    local label=" $file "
+    local label_len=${#label}
+    local fill=$(( (width - label_len) / 2 ))
+    local line=$(printf '═%.0s' $(seq 1 $fill))
+    local line_r=$(printf '═%.0s' $(seq 1 $(( width - fill - label_len )) ))
+    echo ""
+    echo -e "${RED}${BOLD}╔$(printf '═%.0s' $(seq 1 $width))╗${RESET}"
+    echo -e "${RED}${BOLD}║${WHITE}${line}${label}${line_r}${RED}${BOLD}║${RESET}"
+    echo -e "${RED}${BOLD}╚$(printf '═%.0s' $(seq 1 $width))╝${RESET}"
 }
 
 # ── Hunk header ───────────────────────────────────────────────────────────────
 print_hunk_header() {
-	local file="$1"
-	local location="$2"
-	local action="$3"
-	echo -e "\n${BOLD}${WHITE}${file}:${location}${YELLOW}"
+    local file="$1"
+    local location="$2"
+    echo -e "\n${BOLD}${WHITE}${file}:${location}${YELLOW}"
 }
 
 # ── Main loop ─────────────────────────────────────────────────────────────────
 ERRORS=0
 
-for FILE in $FILES; do
-	DIFF=$(diff "$FILE" <(clang-format "$FILE"))
-	if [ -n "$DIFF" ]; then
-		print_file_header "$FILE"
+while IFS= read -r FILE; do
+    [ -z "$FILE" ] && continue
+    DIFF=$(diff "$FILE" <(clang-format "$FILE"))
+    if [ -n "$DIFF" ]; then
+        print_file_header "$FILE"
 
-		in_hunk=false
-		prev_was_expected=false
+        in_hunk=false
+        prev_was_expected=false
 
-		while IFS= read -r line; do
-			if [[ "$line" =~ ^[0-9]+(,[0-9]+)?[acd][0-9]+(,[0-9]+)?$ ]]; then
-				location=$(parse_location "$line")
-				print_hunk_header "$FILE" "$location"
-				in_hunk=true
-				prev_was_expected=false
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^[0-9]+(,[0-9]+)?[acd][0-9]+(,[0-9]+)?$ ]]; then
+                location=$(parse_location "$line")
+                print_hunk_header "$FILE" "$location"
+                in_hunk=true
+                prev_was_expected=false
 
-			elif [[ "$line" == "< "* ]]; then
-				printf "${MAGENTA} [ ORIGINAL ]\t║%s${RESET}\n" "${line:2}"
-				prev_was_expected=true
+            elif [[ "$line" == "< "* ]]; then
+                printf "${MAGENTA} [ ORIGINAL ]\t║%s${RESET}\n" "${line:2}"
+                prev_was_expected=true
 
-			elif [[ "$line" == "> "* ]]; then
-				printf "${BLUE} [ EXPECTED ]\t║%s${RESET}\n" "${line:2}"
-				prev_was_expected=false
-			fi
-		done <<< "$DIFF"
+            elif [[ "$line" == "> "* ]]; then
+                printf "${BLUE} [ EXPECTED ]\t║%s${RESET}\n" "${line:2}"
+                prev_was_expected=false
+            fi
+        done <<< "$DIFF"
 
-		ERRORS=$((ERRORS + 1))
-	fi
-done
+        ERRORS=$((ERRORS + 1))
+    fi
+done <<< "$FILES"
 
-# ── Summary ───────────────────────────────────────────────────────────────────
-if [ "$ERRORS" -gt 0 ]; then
-	echo -e "${RED}${BOLD}$ERRORS file(s) not formatted correctly.${RESET}\n"
-	exit 1
+# ── Format in place if --format was passed ────────────────────────────────────
+if [ "$FORMAT_MODE" = true ]; then
+    if [ "$ERRORS" -gt 0 ]; then
+        echo -e "\n${YELLOW}${BOLD}⚙  Formatting $ERRORS file(s) in place...${RESET}"
+        while IFS= read -r FILE; do
+            [ -z "$FILE" ] && continue
+            clang-format -i "$FILE"
+            echo -e "  ${DIM}formatted: $FILE${RESET}"
+        done <<< "$FILES"
+        echo -e "${GREEN}${BOLD}✅ Done. All files have been formatted.${RESET}\n"
+    else
+        echo -e "${GREEN}${BOLD}✅ All files already correctly formatted.${RESET}\n"
+    fi
+    exit 0
 fi
 
-echo -e "${GREEN}${BOLD}✅  All files correctly formatted.${RESET}\n"
+# ── Summary (check-only mode) ─────────────────────────────────────────────────
+if [ "$ERRORS" -gt 0 ]; then
+    echo -e "${RED}${BOLD}$ERRORS file(s) not formatted correctly.${RESET}\n"
+    exit 1
+fi
+
+echo -e "${GREEN}${BOLD}✅ All files correctly formatted.${RESET}\n"

--- a/docs/engineering-guidelines.md
+++ b/docs/engineering-guidelines.md
@@ -3,7 +3,7 @@
 > This document briefly describes the two formatting configuration files committed to the repository.
 > All engineering guidelines for **ft_irc** are maintained in [`IRC-workflow.md`](./docs/IRC-workflow.md).
 
----
+***
 
 ## `.clang-format`
 
@@ -22,9 +22,7 @@ Key rules at a glance:
 - **Short constructs**: no short functions, `if`, or loops on a single line
 - **Spaces**: before control statement parens (`if (`, `for (`), not before function calls
 
-> For the full CI lint job that checks formatting on every PR, see [§9 – CI with GitHub Actions](./docs/IRC-workflow.md#9-ci-avec-github-actions).
-
----
+***
 
 ## `.editorconfig`
 
@@ -40,33 +38,60 @@ Rules per file type:
 | `*.{yml,yaml}` | Space | 4 | YAML forbids tabs |
 | `*.md` | Tab | 4 | Trailing whitespace **preserved** (two spaces = intentional `<br>`) |
 
-> Code style expectations and formatting requirements are detailed in [§5 – Code Standards](./docs/IRC-workflow.md#5-norme-décriture-du-code).
-
----
+***
 
 ## `check_format.sh`
 
-A `check_format.sh` script is committed at the root of the repository.
-It is a local formatting checker that runs `clang-format` in dry-run mode
-against all C++ source and header files and reports any diff in a
-human-readable, colour-coded output.
+The script is located at `.github/scripts/check_format.sh`.
+It is a local formatting checker and auto-formatter that wraps `clang-format` with
+a human-readable, colour-coded diff output.
 
-Key behaviours:
+### Key behaviours
 
-- **Scope**: scans `src/` and `include/` recursively for `*.cpp`, `*.hpp`, `*.tpp`, `*.ipp`
+- **Scope**: by default, scans `src/` and `include/` recursively for `*.cpp`, `*.hpp`, `*.tpp`, `*.ipp`
+- **Custom targets**: accepts any number of files or directories as positional arguments to restrict the scope
 - **Diff output**: prints the original line (magenta) vs the expected line (blue) for each hunk, grouped per file
-- **Exit code**: exits `1` if any file is incorrectly formatted, `0` if all files pass — suitable for CI
-- **No side effects**: never writes to disk, read-only check only
+- **In-place formatting**: the `--format` flag runs `clang-format -i` on all targeted files after showing the diff
+- **Exit codes**:
+  - `0` — all files correctly formatted, or `--format` was used
+  - `1` — one or more files are incorrectly formatted (check-only mode)
+  - `2` — unknown flag passed
+
+### Options
+
+| Flag | Description |
+|---|---|
+| _(none)_ | Check-only: print diff and exit `1` on any formatting error |
+| `--format` | Print diff, then format all targeted files in place with `clang-format -i`. Always exits `0`. |
+| `--help` | Print the usage message and exit `0`. |
 
 ### Usage
 
 ```bash
-# Run locally before pushing
-bash check_format.sh
+# Check all files under src/ and include/ (default scope)
+.github/scripts/check_format.sh
+
+# Check a single file
+.github/scripts/check_format.sh src/main.cpp
+
+# Check all files under a specific directory
+.github/scripts/check_format.sh includes/core/
+
+# Check a file and a directory together
+.github/scripts/check_format.sh src/main.cpp includes/core/
+
+# Format all default files in place (shows diff first, then formats, exits 0)
+.github/scripts/check_format.sh --format
+
+# Format a specific file in place
+.github/scripts/check_format.sh --format src/main.cpp
+
+# Format a file and a directory in place
+.github/scripts/check_format.sh --format src/main.cpp includes/core/
+
+# Print usage
+.github/scripts/check_format.sh --help
 ```
 
-Run this script before every push to catch formatting issues before the CI lint job does.
+Run this script before every push to catch (or fix) formatting issues before the CI lint job does.
 The script relies on `.clang-format` being present at the root — do not move or rename it.
-
-> This script is the local counterpart of the `lint` CI job described in
-> [§9.3 – Recommended CI jobs](./IRC-workflow.md#9-ci-avec-github-actions).


### PR DESCRIPTION
## Summary

Enhances `.github/scripts/check_format.sh` with two new capabilities:
a `--format` flag to auto-format files in place, and support for positional
arguments to restrict the scope to specific files or directories.
Also adds a `--help` flag documenting all usage. Updates `engineering-guidelines.md`
to reflect the new script location, options, and usage examples.

## Why

The script previously only supported a full diff-check against the hardcoded
`src/` and `include/` directories with no way to fix violations automatically.
Contributors had to run `clang-format -i` manually after identifying issues.
Additionally, there was no way to check or format a subset of files,
which slowed down targeted fixes during development.

## Changes

- Add `--format` flag: prints diff output first, then runs `clang-format -i`
  on all targeted files in place, always exits `0`
- Add positional arguments support: accepts any number of files or directories;
  directories are searched recursively with the existing extension filter;
  defaults to `src/` and `include/` when no targets are given
- Add `--help` flag: prints full usage, options, exit codes, and examples
- Add unknown-flag guard: exits `2` with a pointer to `--help`
- Fix main loop to use `while IFS= read -r` instead of `for FILE in $FILES`
  to correctly handle filenames with spaces
- Update `engineering-guidelines.md`: new script path, key behaviours,
  options table, and full usage examples

## Tests

- [x] `check_format.sh` with no args behaves exactly as before (diff + exit 1)
- [x] `check_format.sh --format` formats files in place and exits 0
- [x] `check_format.sh src/main.cpp` checks a single file only
- [x] `check_format.sh --format includes/core/` formats a directory in place
- [x] `check_format.sh --help` prints usage and exits 0
- [x] `check_format.sh --unknown` exits 2 with error message

## Risks

- The `--format` flag writes to disk — should never be called from the CI lint
  job (which must remain read-only). CI callers must not pass `--format`.
- Renaming the script path from the repo root to `.github/scripts/` may break
  any local alias or Makefile rule contributors have set up pointing to the old location.

## Linked issue
Closes #25

---

## Merge policy

- Use squash or rebase merges only (no merge commits).
- Ensure dependancy are merged and there's no `blocked` label
- Do not merge if any CI check is red.
- Do not merge without at least one review approval.
- Ensure the branch is up to date with main before merging.
