### PR TITLE
Chore/34 Fix DEBUG variable, CFLAGS→CXXFLAGS, and VERBOSE typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/09/29 05:48:20 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/14 18:15:00 by jaubry--         ###   ########.fr        #
+#    Updated: 2026/04/23 03:02:13 by jaubry--         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -26,6 +26,10 @@ INCLUDES	= $(INCDIRS_IRC)
 # Output
 NAME		= ircserv
 
+# Variables
+
+VARS		= DEBUG=$(DEBUG)
+
 # Compiler and flags
 CXX			= c++
 
@@ -38,7 +42,7 @@ IFLAGS		= $(addprefix -I,$(INCLUDES))
 
 VFLAGS		= $(addprefix -D ,$(VARS))
 
-CFLAGS		+= $(INSPECT_FLAGS) $(PROFILE_FLAGS) $(FAST_FLAGS) $(VFLAGS)
+CXXFLAGS	+= $(INSPECT_FLAGS) $(PROFILE_FLAGS) $(FAST_FLAGS) $(VFLAGS)
 
 CF			= $(CXX) $(CXXFLAGS) $(IFLAGS)
 
@@ -58,7 +62,7 @@ include	$(ROOTDIR)/mkidir/make_rules.mk
 
 $(NAME): $(OBJS) $(HEADERS)
 	$(call bin-link-msg)
-ifeq ($(VERBOS),1)
+ifeq ($(VERBOSE),1)
 	$(CF) $(OBJS) -o $@
 else
 	@$(CF) $(OBJS) -o $@


### PR DESCRIPTION
## What
Fixes three bugs in the Makefile:

- **DEBUG** — variable was not properly set; corrected definition and propagation to compilation flags
- **CFLAGS → CXXFLAGS** — the project is C++; all references to `CFLAGS` are replaced with `CXXFLAGS`
- **VERBOS → VERBOSE** — typo in the verbose flag variable name, renamed consistently everywhere

## Why
These bugs caused silent misbehaviour: debug builds were ineffective, compiler flags were not
applied to C++ compilation, and any rule conditional on `VERBOSE` was never triggered.

## Checklist
- [x] `make` (default build) succeeds cleanly
- [x] `make DEBUG=1` produces a debug build with correct flags
- [x] `VERBOSE=1 make` produces verbose output
- [x] No existing rules regressed (clean, fclean, re)
## Linked issue

Closes #34 

---

## Merge policy

- Use squash or rebase merges only (no merge commits).
- Ensure dependancy are merged and there's no `blocked` label
- Do not merge if any CI check is red.
- Do not merge without at least one review approval.
- Ensure the branch is up to date with main before merging.
