### PR TITLE
Chore/33 format cppcheck submodule makefile rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/09/29 05:48:20 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/23 03:24:16 by jaubry--         ###   ########.fr        #
+#    Updated: 2026/04/23 03:24:59 by jaubry--         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -74,6 +74,11 @@ cppcheck:
 
 formatcheck:
 	@./.github/scripts/check_format.sh src include
+
+submodules:
+	git submodule init
+	git submodule sync
+	git submodule update --remote
 
 help:
 	@echo "Available targets:"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/09/29 05:48:20 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/23 03:02:13 by jaubry--         ###   ########.fr        #
+#    Updated: 2026/04/23 03:23:35 by jaubry--         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -68,6 +68,9 @@ else
 	@$(CF) $(OBJS) -o $@
 endif
 	$(call bin-finish-msg)
+
+cppcheck:
+	@./.github/scripts/run_cppcheck.sh
 
 help:
 	@echo "Available targets:"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/09/29 05:48:20 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/14 18:15:00 by jaubry--         ###   ########.fr        #
+#    Updated: 2026/04/23 03:02:13 by jaubry--         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -26,6 +26,10 @@ INCLUDES	= $(INCDIRS_IRC)
 # Output
 NAME		= ircserv
 
+# Variables
+
+VARS		= DEBUG=$(DEBUG)
+
 # Compiler and flags
 CXX			= c++
 
@@ -38,7 +42,7 @@ IFLAGS		= $(addprefix -I,$(INCLUDES))
 
 VFLAGS		= $(addprefix -D ,$(VARS))
 
-CFLAGS		+= $(INSPECT_FLAGS) $(PROFILE_FLAGS) $(FAST_FLAGS) $(VFLAGS)
+CXXFLAGS	+= $(INSPECT_FLAGS) $(PROFILE_FLAGS) $(FAST_FLAGS) $(VFLAGS)
 
 CF			= $(CXX) $(CXXFLAGS) $(IFLAGS)
 
@@ -58,7 +62,7 @@ include	$(ROOTDIR)/mkidir/make_rules.mk
 
 $(NAME): $(OBJS) $(HEADERS)
 	$(call bin-link-msg)
-ifeq ($(VERBOS),1)
+ifeq ($(VERBOSE),1)
 	$(CF) $(OBJS) -o $@
 else
 	@$(CF) $(OBJS) -o $@

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/09/29 05:48:20 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/23 03:24:59 by jaubry--         ###   ########.fr        #
+#    Updated: 2026/04/23 03:26:18 by jaubry--         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -69,11 +69,13 @@ else
 endif
 	$(call bin-finish-msg)
 
-cppcheck:
+check-cpp:
 	@./.github/scripts/run_cppcheck.sh
 
-formatcheck:
+check-format:
 	@./.github/scripts/check_format.sh src include
+
+check-all: check-cpp check-format
 
 submodules:
 	git submodule init
@@ -102,3 +104,5 @@ fclean:
 	@rm -rf $(OBJDIR) $(DEPDIR)
 	$(call rm-bin-msg)
 	@rm -f $(NAME)
+
+.PHONY: check-cpp check-format check submodules

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/09/29 05:48:20 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/23 03:23:35 by jaubry--         ###   ########.fr        #
+#    Updated: 2026/04/23 03:24:16 by jaubry--         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -71,6 +71,9 @@ endif
 
 cppcheck:
 	@./.github/scripts/run_cppcheck.sh
+
+formatcheck:
+	@./.github/scripts/check_format.sh src include
 
 help:
 	@echo "Available targets:"


### PR DESCRIPTION
## What
Adds three new phony rules to the Makefile:

- `format-check` — runs the clang-format script under `.github/` to validate formatting across all source files
- `cppcheck` — runs cppcheck static analysis on the project sources
- `submodule-update` — updates all submodules to their latest remote state via:
  git submodule init ; git submodule sync ; git submodule update --remote

## Why
These rules were missing, forcing contributors to run tooling manually and inconsistently.
Exposing them through the Makefile aligns with the existing `make` workflow and makes CI integration straightforward.

## Checklist
- [ ] `make format-check` renamed to `make check-format`
- [ ] `make cppcheck` renamed to `make check-cpp`
- [ ] `make check-all` runs both `check-format` and `check-cpp`
- [ ] All new targets added to `.PHONY`

## Dependancies

Resolves #33 
Needs #35 merged first