### PR TITLE
chore/21 Wire clang-format-14 check into CI pipeline

### DIFF
--- a/.github/workflows/ci-check-format.yaml
+++ b/.github/workflows/ci-check-format.yaml
@@ -1,0 +1,19 @@
+name: CI — clang-format check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get install -y clang-format-14
+          sudo ln -sf /usr/bin/clang-format-14 /usr/local/bin/clang-format
+
+      - name: Run clang-format check
+        run: bash .github/scripts/check_format.sh


### PR DESCRIPTION
## Summary
Wires the existing `check_format.sh` script from #17 into a GitHub Actions CI job that runs on every pull request targeting `main` and fails if any source file is not compliant with `.clang-format`.

## Why
The format check script existed but was never enforced automatically. Without CI enforcement, non-compliant files can silently land on `main`. This closes the gap.

## Changes
- Add `.github/workflows/ci-check-format.yaml` — installs `clang-format-14`, symlinks it as `clang-format`, then runs `check_format.sh` against `src/` and `include/`

## Tests
- [ ] CI job passes on a correctly formatted branch
- [ ] CI job fails and surfaces the diff when a file is not compliant

## Risks
- If `clang-format-14` is not available on the runner's apt mirror the install step will fail — no functional risk to the codebase but the CI job itself would be broken

## Linked issue
Closes #21

***

## Merge policy

- Use squash or rebase merges only (no merge commits).
- Ensure dependancy are merged and there's no `blocked` label
- Do not merge if any CI check is red.
- Do not merge without at least one review approval.
- Ensure the branch is up to date with main before merging.