### PR TITLE
chore(ci): auto-remove state:blocked from stacked PRs on base branch …

### DIFF
--- a/.github/scripts/auto-unblock-on-merge.js
+++ b/.github/scripts/auto-unblock-on-merge.js
@@ -1,0 +1,58 @@
+// Trigger:  pull_request closed (merged only), targeting main
+// Reads:    the merged branch name from context
+// Finds:    all open PRs whose base branch = merged branch
+// Writes:   removes state:blocked from each found PR and its linked issue
+//           (issue number parsed from PR title: type/<issue> description)
+
+module.exports = async ({ github, context }) => {
+  const mergedBranch = context.payload.pull_request.head.ref;
+
+  console.log(`[unblock-on-merge] Merged branch: ${mergedBranch}`);
+
+  // Find all open PRs that were stacked on the merged branch
+  const { data: openPRs } = await github.rest.pulls.list({
+    ...context.repo,
+    state: 'open',
+    base: mergedBranch,
+  });
+
+  if (openPRs.length === 0) {
+    console.log('[unblock-on-merge] No stacked PRs found — nothing to unblock.');
+    return;
+  }
+
+  console.log(`[unblock-on-merge] Found ${openPRs.length} stacked PR(s) to unblock.`);
+
+  for (const pr of openPRs) {
+    console.log(`[unblock-on-merge] Processing PR #${pr.number}: "${pr.title}"`);
+
+    // Remove state:blocked from the PR
+    await github.rest.issues.removeLabel({
+      ...context.repo,
+      issue_number: pr.number,
+      name: 'state:blocked',
+    }).catch(() => {
+      console.log(`[unblock-on-merge] PR #${pr.number} had no state:blocked — skipping.`);
+    });
+
+    // Parse linked issue from PR title: type/<issue-number> description
+    const titleMatch = pr.title.match(/^[a-z]+\/(\d+)(?:\s|$)/i);
+    if (!titleMatch) {
+      console.log(`[unblock-on-merge] PR #${pr.number} title does not match convention — skipping issue unblock.`);
+      continue;
+    }
+
+    const issueNumber = parseInt(titleMatch[1]);
+    console.log(`[unblock-on-merge] Removing state:blocked from linked issue #${issueNumber}`);
+
+    await github.rest.issues.removeLabel({
+      ...context.repo,
+      issue_number: issueNumber,
+      name: 'state:blocked',
+    }).catch(() => {
+      console.log(`[unblock-on-merge] Issue #${issueNumber} had no state:blocked — skipping.`);
+    });
+  }
+
+  console.log('[unblock-on-merge] ✅ Done.');
+};

--- a/.github/scripts/auto-unblock-on-merge.js
+++ b/.github/scripts/auto-unblock-on-merge.js
@@ -1,58 +1,39 @@
-// Trigger:  pull_request closed (merged only), targeting main
-// Reads:    the merged branch name from context
-// Finds:    all open PRs whose base branch = merged branch
-// Writes:   removes state:blocked from each found PR and its linked issue
-//           (issue number parsed from PR title: type/<issue> description)
-
 module.exports = async ({ github, context }) => {
-  const mergedBranch = context.payload.pull_request.head.ref;
+  const pr = context.payload.pull_request;
 
-  console.log(`[unblock-on-merge] Merged branch: ${mergedBranch}`);
-
-  // Find all open PRs that were stacked on the merged branch
-  const { data: openPRs } = await github.rest.pulls.list({
-    ...context.repo,
-    state: 'open',
-    base: mergedBranch,
-  });
-
-  if (openPRs.length === 0) {
-    console.log('[unblock-on-merge] No stacked PRs found — nothing to unblock.');
+  // Parse original issue from PR title: type/<issue-number> description
+  const titleMatch = pr.title.match(/^[a-z]+\/(\d+)(?:\s|$)/i);
+  if (!titleMatch) {
+    console.log('[copy-labels] PR title does not match convention — skipping.');
     return;
   }
 
-  console.log(`[unblock-on-merge] Found ${openPRs.length} stacked PR(s) to unblock.`);
+  const issueNumber = parseInt(titleMatch[1]);
 
-  for (const pr of openPRs) {
-    console.log(`[unblock-on-merge] Processing PR #${pr.number}: "${pr.title}"`);
+  const { data: issue } = await github.rest.issues.get({
+    ...context.repo,
+    issue_number: issueNumber,
+  }).catch(() => ({ data: null }));
 
-    // Remove state:blocked from the PR
-    await github.rest.issues.removeLabel({
-      ...context.repo,
-      issue_number: pr.number,
-      name: 'state:blocked',
-    }).catch(() => {
-      console.log(`[unblock-on-merge] PR #${pr.number} had no state:blocked — skipping.`);
-    });
-
-    // Parse linked issue from PR title: type/<issue-number> description
-    const titleMatch = pr.title.match(/^[a-z]+\/(\d+)(?:\s|$)/i);
-    if (!titleMatch) {
-      console.log(`[unblock-on-merge] PR #${pr.number} title does not match convention — skipping issue unblock.`);
-      continue;
-    }
-
-    const issueNumber = parseInt(titleMatch[1]);
-    console.log(`[unblock-on-merge] Removing state:blocked from linked issue #${issueNumber}`);
-
-    await github.rest.issues.removeLabel({
-      ...context.repo,
-      issue_number: issueNumber,
-      name: 'state:blocked',
-    }).catch(() => {
-      console.log(`[unblock-on-merge] Issue #${issueNumber} had no state:blocked — skipping.`);
-    });
+  if (!issue) {
+    console.log(`[copy-labels] Issue #${issueNumber} not found — skipping.`);
+    return;
   }
 
-  console.log('[unblock-on-merge] ✅ Done.');
+  const toCopy = issue.labels
+    .map(l => l.name)
+    .filter(n => n.startsWith('type:') || n.startsWith('priority:'));
+
+  if (toCopy.length === 0) {
+    console.log(`[copy-labels] No type:/priority: labels on issue #${issueNumber} — skipping.`);
+    return;
+  }
+
+  console.log(`[copy-labels] Copying labels from issue #${issueNumber} to PR #${pr.number}: ${toCopy.join(', ')}`);
+
+  await github.rest.issues.addLabels({
+    ...context.repo,
+    issue_number: pr.number,
+    labels: toCopy,
+  });
 };

--- a/.github/workflows/auto-unblock-on-merge.yaml
+++ b/.github/workflows/auto-unblock-on-merge.yaml
@@ -1,0 +1,24 @@
+name: Automation — remove state:blocked on base branch merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  unblock:
+    name: Remove state:blocked from stacked PRs and their issues
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remove state:blocked from stacked PRs and linked issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fn = require('./.github/scripts/automation/unblock-on-merge.js');
+            await fn({ github, context });


### PR DESCRIPTION
## Summary
Adds a workflow that fires whenever a PR is merged into `main` and automatically removes `state:blocked` from any open PR that was stacked on top of the just-merged branch, and from each such PR's linked issue.

## Why
`state:blocked` was applied automatically on PR open but never lifted automatically. Once the blocking branch merged, the label had to be removed manually. This closes that gap.

## Changes
- Add `auto-unblock-on-merge.yaml` — triggers on `pull_request: closed` targeting `main`, runs only when merged
- Add `automation/unblock-on-merge.js` — queries all open PRs with `base = merged-branch`, removes `state:blocked` from each and from their linked issue parsed via `type/<issue>` title convention

## Tests
- [ ] Merging a PR unblocks any open PR whose base was the merged branch
- [ ] The linked issue of each unblocked PR also loses `state:blocked`
- [ ] PRs with no `state:blocked` label silently no-op without failing the job
- [ ] PRs not stacked on the merged branch are unaffected

## Risks
- Uses `pulls.list({ base: mergedBranch })` — only finds PRs explicitly targeting that branch as base, not transitively stacked chains (e.g. C stacked on B stacked on A — merging A only unblocks B, not C directly; C gets unblocked when B is later merged)

## Linked issue
Closes #40

***

## Merge policy

- Use squash or rebase merges only (no merge commits).
- Ensure dependancy are merged and there's no `blocked` label
- Do not merge if any CI check is red.
- Do not merge without at least one review approval.
- Ensure the branch is up to date with main before merging.