### PR TITLE
chore(Makefile): Added help infos about new commands in make help (#44)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: ekeisler <ekeisler@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/09/29 05:48:20 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/23 16:04:32 by ekeisler         ###   ########.fr        #
+#    Updated: 2026/04/23 17:10:08 by ekeisler         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -88,15 +88,27 @@ help:
 	@echo -e "\tdebug\t\t\t\t: Build the program with debug symbols"
 	@echo -e "\tre\t\t\t\t: Rebuild $(NAME)"
 	@echo
-	@echo -e "\tfast\t\t\t\t: Build the program with fast symbols"
+	@echo -e "\tfast\t\t\t\t: Build with -Ofast -march=native optimizations"
+	@echo -e "\trefast\t\t\t\t: Rebuild $(NAME) with fast optimizations"
 	@echo
-	@echo -e "\tclean\t\t\t\t: Remove object files"
-	@echo -e "\tfclean\t\t\t\t: Remove object files, libraries and program"
+	@echo -e "\tinspect\t\t\t\t: Build with -g3 for deep inspection (no sanitizer)"
+	@echo -e "\tprofile\t\t\t\t: Build with -g3 -pg for gprof profiling"
+	@echo
+	@echo "Sanitizers:"
+	@echo -e "\tsan-mem\t\t\t\t: Build with AddressSanitizer (heap/stack overflow, use-after-free)"
+	@echo -e "\tsan-leak\t\t\t: Build with LeakSanitizer (memory leak detection)"
+	@echo -e "\tsan-ub\t\t\t\t: Build with UndefinedBehaviorSanitizer (all UB categories)"
+	@echo -e "\tresan-mem\t\t\t: Rebuild with AddressSanitizer"
+	@echo -e "\tresan-leak\t\t\t: Rebuild with LeakSanitizer"
+	@echo -e "\tresan-ub\t\t\t: Rebuild with UndefinedBehaviorSanitizer"
 	@echo
 	@echo "Quality checks:"
 	@echo -e "\tcheck-format\t\t\t: Check clang-format compliance on src/ and include/"
 	@echo -e "\tcheck-cpp\t\t\t: Run cppcheck static analysis"
 	@echo -e "\tcheck-all\t\t\t: Run check-format and check-cpp"
+	@echo
+	@echo -e "\tclean\t\t\t\t: Remove object files"
+	@echo -e "\tfclean\t\t\t\t: Remove object files, libraries and program"
 	@echo
 	@echo -e "\tprint-%\t\t\t\t: Prints makefile variable content when replacing '%'"
 

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
+#    By: ekeisler <ekeisler@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/09/29 05:48:20 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/23 03:26:18 by jaubry--         ###   ########.fr        #
+#    Updated: 2026/04/23 16:04:32 by ekeisler         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -93,6 +93,11 @@ help:
 	@echo -e "\tclean\t\t\t\t: Remove object files"
 	@echo -e "\tfclean\t\t\t\t: Remove object files, libraries and program"
 	@echo
+	@echo "Quality checks:"
+	@echo -e "\tcheck-format\t\t\t: Check clang-format compliance on src/ and include/"
+	@echo -e "\tcheck-cpp\t\t\t: Run cppcheck static analysis"
+	@echo -e "\tcheck-all\t\t\t: Run check-format and check-cpp"
+	@echo
 	@echo -e "\tprint-%\t\t\t\t: Prints makefile variable content when replacing '%'"
 
 clean:
@@ -105,4 +110,4 @@ fclean:
 	$(call rm-bin-msg)
 	@rm -f $(NAME)
 
-.PHONY: check-cpp check-format check submodules
+.PHONY: check-cpp check-format check-all submodules


### PR DESCRIPTION
…akefile with make help command (#44)

## Summary

Updates the `make help` command to document the three new quality check rules (`check-format`, `check-cpp`, `check-all`) that were added to the `Makefile` but never exposed in the help output.

## Why

Contributors had no way to discover the new check rules via `make help`. The help target was outdated and did not reflect the current state of the `Makefile`, making the quality check workflow invisible to anyone who hadn't read the source directly.

## Changes

- Added a `Quality checks:` section to the `help` target documenting `check-format`, `check-cpp`, and `check-all`
- Added `check-all` to `.PHONY` (it was missing — only `check-cpp` and `check-format` were declared)

## Tests
- [x] Code compiles with `-Wall -Wextra -Werror -std=c++98`, no warnings
- [x] `make help` output displays the three new rules with correct descriptions
- [x] `make check-format`, `make check-cpp`, and `make check-all` still run correctly after the change

## Risks

No functional risk — this is a documentation-only change to the `help` target. The only behavioral change is adding `check-all` to `.PHONY`, which prevents Make from looking for a file named `check-all` (correct behavior, no regression).

## Linked issue
Closes #44 

---

## Merge policy

- Use squash or rebase merges only (no merge commits).
- Ensure dependancy are merged and there's no `blocked` label
- Do not merge if any CI check is red.
- Do not merge without at least one review approval.
- Ensure the branch is up to date with main before merging.
