### PR TITLE
chore(ci): Added the `--check-level=exhaustive` flag to `run_cppcheck.sh` (#48)

### DIFF
--- a/.github/scripts/run_cppcheck.sh
+++ b/.github/scripts/run_cppcheck.sh
@@ -22,6 +22,7 @@ cppcheck \
 	--language=c++ \
 	--inline-suppr \
 	--error-exitcode=1 \
+	--check-level=exhaustive \
 	--suppress=missingIncludeSystem \
 	${INCLUDE_FLAGS} \
 	src


### PR DESCRIPTION
## Summary

This flag forces cppcheck to perform exhaustive analysis on all code paths, including those it would normally skip for performance reasons.

## Changes
Added the `--check-level=exhaustive` flag to `run_cppcheck.sh` 

## Tests
- [x] `--check-level=exhaustive` is added to the cppcheck invocation in the CI script
- [x] CI still passes on a clean codebase
- [x] CI fails if cppcheck reports any new finding surfaced by the exhaustive pass

## Risks
No logic was modified. Risk of regression is minimal. Formatting-only diff may cause minor conflicts with branches that touched 

## Linked issue
Closes #48 

---

## Merge policy

- Use squash or rebase merges only (no merge commits).
- Ensure dependancy are merged and there's no `blocked` label
- Do not merge if any CI check is red.
- Do not merge without at least one review approval.
- Ensure the branch is up to date with main before merging.
