### PR TITLE
chore/75  Pin cppcheck to 2.20.0 built from source in CI

### DIFF
--- a/.github/workflows/cppcheck.yaml
+++ b/.github/workflows/cppcheck.yaml
@@ -1,12 +1,12 @@
 # **************************************************************************** #
 #                                                                              #
 #                                                         :::      ::::::::    #
-#    cppcheck.yml                                       :+:      :+:    :+:    #
+#    cppcheck.yaml                                      :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
 #    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2026/04/16 18:40:05 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/16 18:41:38 by jaubry--         ###   ########.fr        #
+#    Updated: 2026/04/24 16:45:13 by jaubry--         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -28,8 +28,30 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install cppcheck
-        run: sudo apt-get update && sudo apt-get install -y cppcheck
+      - name: Cache cppcheck 2.20.0 build
+        id: cache-cppcheck
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/cppcheck
+          key: cppcheck-2.20.0-ubuntu-latest
+
+      - name: Install cppcheck 2.20.0 from source
+        if: steps.cache-cppcheck.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake make libpcre3-dev
+          git clone https://github.com/danmar/cppcheck.git /tmp/cppcheck
+          cd /tmp/cppcheck
+          git checkout 2.20.0
+          cmake -S . -B build \
+            -DHAVE_RULES=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/usr/local
+          cmake --build build -j$(nproc)
+          sudo cmake --install build
+
+      - name: Verify cppcheck version
+        run: cppcheck --version
 
       - name: Run cppcheck
         run: ./.github/scripts/run_cppcheck.sh


### PR DESCRIPTION
## Description
Replaces `apt-get install cppcheck` (which installs 2.13) with a source
build pinned to the exact `2.20.0` tag from `danmar/cppcheck`.

## Why ?
The apt package on ubuntu-latest is frozen at 2.13 and does not receive
upstream updates. Pinning from source guarantees the exact version used
locally matches CI.

## Changes
- Remove `apt-get install cppcheck`
- Add `actions/cache@v4` step keyed on `cppcheck-2.20.0-ubuntu-latest`
- Add source build step (cmake, `HAVE_RULES=ON`, Release mode)
- Add `cppcheck --version` verification step

## Tests
- Verified `cppcheck --version` outputs `Cppcheck 2.20.0` in CI logs
- Cache hit confirmed on second run (build step skipped)
- `run_cppcheck.sh` passes without error

## Risks
- First run is ~1–2 min longer due to compilation; mitigated by the cache
- If the cache is evicted, the build reruns transparently

## Linked issue
Closes #75 