### PR TITLE
chore/78 Fix cppcheck 2.20.0 cache restoring only the binary

### DIFF
--- a/.github/workflows/cppcheck.yaml
+++ b/.github/workflows/cppcheck.yaml
@@ -5,8 +5,8 @@
 #                                                     +:+ +:+         +:+      #
 #    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
-#    Created: 2026/04/16 18:40:05 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/24 16:45:13 by jaubry--         ###   ########.fr        #
+#    Created: 2026/04/24 17:23:42 by jaubry--          #+#    #+#              #
+#    Updated: 2026/04/24 17:23:44 by jaubry--         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -28,27 +28,39 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Cache cppcheck 2.20.0 build
+      - name: Restore cppcheck 2.20.0 cache
         id: cache-cppcheck
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
-          path: /usr/local/bin/cppcheck
-          key: cppcheck-2.20.0-ubuntu-latest
+          path: /tmp/cppcheck-install
+          key: cppcheck-2.20.0-${{ runner.os }}
 
-      - name: Install cppcheck 2.20.0 from source
+      - name: Install build dependencies
+        if: steps.cache-cppcheck.outputs.cache-hit != 'true'
+        run: sudo apt-get update && sudo apt-get install -y cmake make libpcre3-dev
+
+      - name: Build cppcheck 2.20.0 from source
         if: steps.cache-cppcheck.outputs.cache-hit != 'true'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake make libpcre3-dev
-          git clone https://github.com/danmar/cppcheck.git /tmp/cppcheck
-          cd /tmp/cppcheck
+          git clone https://github.com/danmar/cppcheck.git /tmp/cppcheck-src
+          cd /tmp/cppcheck-src
           git checkout 2.20.0
           cmake -S . -B build \
-            -DHAVE_RULES=ON \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX=/usr/local
+          -DHAVE_RULES=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/tmp/cppcheck-install
           cmake --build build -j$(nproc)
-          sudo cmake --install build
+          cmake --install build
+
+      - name: Save cppcheck 2.20.0 cache
+        if: steps.cache-cppcheck.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/cppcheck-install
+          key: cppcheck-2.20.0-${{ runner.os }}
+
+      - name: Symlink cppcheck to PATH
+        run: sudo ln -sf /tmp/cppcheck-install/bin/cppcheck /usr/local/bin/cppcheck
 
       - name: Verify cppcheck version
         run: cppcheck --version


### PR DESCRIPTION
## Summary
The cppcheck CI job worked on first run but crashed on subsequent runs
due to a broken cache strategy: only the binary was cached, not the
full cmake install tree.

## Why
`cmake --install` deploys files across `/usr/local/bin/`, `/usr/local/lib/`,
and `/usr/local/share/`. Restoring only the binary left all dependencies
missing, causing an immediate crash at `cppcheck --version`.

## Changes
- Cache path changed from `/usr/local/bin/cppcheck` to `/tmp/cppcheck-install` (full prefix)
- `cmake --install` now targets `/tmp/cppcheck-install` (no sudo required)
- Replaced `actions/cache@v4` with split `actions/cache/restore` + `actions/cache/save`
- `cache/save` is conditional (`cache-hit != 'true'`) to avoid saving partial state
- Added unconditional `ln -sf` symlink step to always expose binary in PATH
- Cache key now includes `${{ runner.os }}` to prevent cross-OS mismatches

## Tests
- Verified `cppcheck --version` outputs `Cppcheck 2.20.0` on cache miss (fresh build)
- Verified `cppcheck --version` outputs `Cppcheck 2.20.0` on cache hit (build skipped)
- `run_cppcheck.sh` passes without error on both runs

## Risks
- None: the symlink step acts as a safety net regardless of cache state

## Linked issue
Closes #78 