### PR TITLE
chore/80 Statically link libpcre into cppcheck to fix cache hit failures

### DIFF
--- a/.github/workflows/cppcheck.yaml
+++ b/.github/workflows/cppcheck.yaml
@@ -5,8 +5,8 @@
 #                                                     +:+ +:+         +:+      #
 #    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
-#    Created: 2026/04/24 17:47:14 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/24 17:47:16 by jaubry--         ###   ########.fr        #
+#    Created: 2026/04/24 18:07:20 by jaubry--          #+#    #+#              #
+#    Updated: 2026/04/24 18:07:31 by jaubry--         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -33,11 +33,22 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: /tmp/cppcheck-install
-          key: cppcheck-2.20.0-${{ runner.os }}
+          key: cppcheck-2.20.0-selfcontained-${{ runner.os }}
 
       - name: Install build dependencies
         if: steps.cache-cppcheck.outputs.cache-hit != 'true'
-        run: sudo apt-get update && sudo apt-get install -y cmake make libpcre3-dev
+        run: sudo apt-get update && sudo apt-get install -y cmake make wget
+
+      - name: Build PCRE from source (static)
+        if: steps.cache-cppcheck.outputs.cache-hit != 'true'
+        run: |
+          cd /tmp
+          wget -q https://sourceforge.net/projects/pcre/files/pcre/8.45/pcre-8.45.tar.gz
+          tar -xzf pcre-8.45.tar.gz
+          cd pcre-8.45
+          ./configure --prefix=/tmp/pcre-static --disable-shared --enable-static
+          make -j$(nproc)
+          make install
 
       - name: Build cppcheck 2.20.0 from source
         if: steps.cache-cppcheck.outputs.cache-hit != 'true'
@@ -46,20 +57,32 @@ jobs:
           cd /tmp/cppcheck-src
           git checkout 2.20.0
           cmake -S . -B build \
-            -DHAVE_RULES=ON \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX=/tmp/cppcheck-install \
-            -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
-            -DPCRE_STATIC=ON
+          -DHAVE_RULES=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/tmp/cppcheck-install \
+          -DPCRE_INCLUDE_DIR=/tmp/pcre-static/include \
+          -DPCRE_LIBRARY=/tmp/pcre-static/lib/libpcre.a \
+          -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++"
           cmake --build build -j$(nproc)
           cmake --install build
+
+      - name: Verify binary is self-contained
+        if: steps.cache-cppcheck.outputs.cache-hit != 'true'
+        run: |
+          result=$(ldd /tmp/cppcheck-install/bin/cppcheck | grep pcre || true)
+          if [ -n "$result" ]; then
+        echo "ERROR: pcre is still dynamically linked:"
+        echo "$result"
+        exit 1
+        fi
+        echo "OK: pcre is statically linked"
 
       - name: Save cppcheck 2.20.0 cache
         if: steps.cache-cppcheck.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: /tmp/cppcheck-install
-          key: cppcheck-2.20.0-${{ runner.os }}
+          key: cppcheck-2.20.0-selfcontained-${{ runner.os }}
 
       - name: Symlink cppcheck to PATH
         run: sudo ln -sf /tmp/cppcheck-install/bin/cppcheck /usr/local/bin/cppcheck

--- a/.github/workflows/cppcheck.yaml
+++ b/.github/workflows/cppcheck.yaml
@@ -5,8 +5,8 @@
 #                                                     +:+ +:+         +:+      #
 #    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
-#    Created: 2026/04/24 17:23:42 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/24 17:23:44 by jaubry--         ###   ########.fr        #
+#    Created: 2026/04/24 17:47:14 by jaubry--          #+#    #+#              #
+#    Updated: 2026/04/24 17:47:16 by jaubry--         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -46,9 +46,11 @@ jobs:
           cd /tmp/cppcheck-src
           git checkout 2.20.0
           cmake -S . -B build \
-          -DHAVE_RULES=ON \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_INSTALL_PREFIX=/tmp/cppcheck-install
+            -DHAVE_RULES=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/tmp/cppcheck-install \
+            -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
+            -DPCRE_STATIC=ON
           cmake --build build -j$(nproc)
           cmake --install build
 

--- a/.github/workflows/cppcheck.yaml
+++ b/.github/workflows/cppcheck.yaml
@@ -6,7 +6,7 @@
 #    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2026/04/24 18:07:20 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/24 18:07:31 by jaubry--         ###   ########.fr        #
+#    Updated: 2026/04/24 18:11:46 by jaubry--         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -57,12 +57,12 @@ jobs:
           cd /tmp/cppcheck-src
           git checkout 2.20.0
           cmake -S . -B build \
-          -DHAVE_RULES=ON \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_INSTALL_PREFIX=/tmp/cppcheck-install \
-          -DPCRE_INCLUDE_DIR=/tmp/pcre-static/include \
-          -DPCRE_LIBRARY=/tmp/pcre-static/lib/libpcre.a \
-          -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++"
+            -DHAVE_RULES=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/tmp/cppcheck-install \
+            -DPCRE_INCLUDE_DIR=/tmp/pcre-static/include \
+            -DPCRE_LIBRARY=/tmp/pcre-static/lib/libpcre.a \
+            -DCMAKE_EXE_LINKER_FLAGS='-static-libgcc -static-libstdc++'
           cmake --build build -j$(nproc)
           cmake --install build
 
@@ -71,11 +71,11 @@ jobs:
         run: |
           result=$(ldd /tmp/cppcheck-install/bin/cppcheck | grep pcre || true)
           if [ -n "$result" ]; then
-        echo "ERROR: pcre is still dynamically linked:"
-        echo "$result"
-        exit 1
-        fi
-        echo "OK: pcre is statically linked"
+            echo "ERROR: pcre is still dynamically linked:"
+            echo "$result"
+            exit 1
+          fi
+          echo "OK: pcre is statically linked"
 
       - name: Save cppcheck 2.20.0 cache
         if: steps.cache-cppcheck.outputs.cache-hit != 'true'

--- a/.github/workflows/cppcheck.yaml
+++ b/.github/workflows/cppcheck.yaml
@@ -6,7 +6,7 @@
 #    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2026/04/24 18:07:20 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/24 18:11:46 by jaubry--         ###   ########.fr        #
+#    Updated: 2026/04/24 18:15:21 by jaubry--         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -60,7 +60,7 @@ jobs:
             -DHAVE_RULES=ON \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=/tmp/cppcheck-install \
-            -DPCRE_INCLUDE_DIR=/tmp/pcre-static/include \
+            -DPCRE_INCLUDE=/tmp/pcre-static/include \
             -DPCRE_LIBRARY=/tmp/pcre-static/lib/libpcre.a \
             -DCMAKE_EXE_LINKER_FLAGS='-static-libgcc -static-libstdc++'
           cmake --build build -j$(nproc)


### PR DESCRIPTION
## Summary
Replace all unreliable static linking attempts with a guaranteed approach:
build PCRE 8.45 from source and point cmake directly at the resulting .a file.

## Why
Previous approaches failed silently:
- `-DPCRE_STATIC=ON` relies on cmake finding a .a, not guaranteed on Ubuntu 24.04
- `-Wl,-Bstatic -lpcre` silently falls back to dynamic if only .so is present
- The binary was cached before verifying it was actually self-contained

This meant every cache hit restored a dynamically linked binary missing its
runtime dependency, causing an immediate crash.

## Changes
- Add a dedicated step to build PCRE 8.45 from source (`--disable-shared --enable-static`)
- Point cmake at the exact `.a` path via `-DPCRE_LIBRARY=/tmp/pcre-static/lib/libpcre.a`
- Add `-DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++"` for full containment
- Add `ldd` verification step that fails the job if pcre is still dynamically linked
- Move `cache/save` after the `ldd` guard — broken binaries can never be cached
- Update cache key to `cppcheck-2.20.0-selfcontained-${{ runner.os }}`
- Remove all unconditional apt install steps — zero deps on cache hit

## Tests
- Verified `cppcheck --version` outputs `Cppcheck 2.20.0` on cache miss
- Verified `ldd` shows no pcre dynamic dependency before cache is saved
- Verified `cppcheck --version` outputs `Cppcheck 2.20.0` on cache hit with no apt steps
- `run_cppcheck.sh` passes without error on both runs

## Risks
- PCRE 8.45 tarball is fetched from sourceforge.net at build time — if the mirror
  is unreliable, the tarball can be committed to .github/deps/ as a fallback

## Linked issue
Closes #80