### PR TITLE
Fix/94 Reject LF in validStr parameter validation

### DIFF
--- a/src/commands/ACommand.cpp
+++ b/src/commands/ACommand.cpp
@@ -6,7 +6,7 @@
 /*   By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/23 17:00:04 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/25 02:55:41 by jaubry--         ###   ########.fr       */
+/*   Updated: 2026/04/25 17:55:58 by jaubry--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,7 +71,7 @@ ACommand::validWord(const std::string& str)
 bool
 ACommand::validStr(const std::string& str)
 {
-	return (str.find_first_of(std::string("\x00\r", 2)) == std::string::npos);
+	return (str.find_first_of(std::string("\x00\r\n", 3)) == std::string::npos);
 }
 
 /*


### PR DESCRIPTION
## Summary
Fixes `ACommand::validStr` to correctly reject LF (`\n`) characters in IRC message parameters, in addition to NUL and CR which were already handled.

## Why
RFC 1459 and RFC 2812 explicitly forbid NUL, CR, **and** LF in all IRC message parameters — including the trailing one. `validStr` was only rejecting NUL and CR, meaning a standalone `\n` (without `\r`) would silently pass validation and reach the message processing logic, potentially breaking message framing.

> RFC 1459: `<trailing> ::= <Any, possibly *empty*, sequence of octets not including NUL or CR or LF>`

## Changes
- Added `\n` to the rejected character set in `ACommand::validStr`
- Updated the byte count argument in `std::string(const char*, size_t)` from `2` to `3` to account for the added character

## Tests
- [x] Code compiles with `-Wall -Wextra -Werror -std=c++98`, no warnings
- [x] Manual test with `nc -C 127.0.0.1 6667` when relevant
- [x] Manual test with the reference IRC client when relevant
- [x] Edge cases tested: message containing standalone `\n` is rejected; valid trailing with spaces and colons still passes

## Risks
Low. The change is additive — it only rejects characters that were already forbidden by the RFC. No valid input should ever contain a raw `\n`, so no legitimate use case should regress.

## Linked issue
Closes #94

***

## Merge policy

- Use squash or rebase merges only (no merge commits).
- Ensure dependencies are merged and there's no `blocked` label.
- Do not merge if any CI check is red.
- Do not merge without at least one review approval.
- Ensure the branch is up to date with main before merging.