### PR TITLE
Task/103 server members implementation

### DIFF
--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -12,8 +12,8 @@
 
 #ifndef CHANNEL_HPP
 #define CHANNEL_HPP
-#include <algorithm>
 #include <Client.hpp>
+#include <algorithm>
 #include <sstream>
 
 class Channel

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -6,14 +6,15 @@
 /*   By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/27 21:00:50 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/27 23:59:26 by jaubry--         ###   ########.fr       */
+/*   Updated: 2026/04/28 02:14:12 by jaubry--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef CHANNEL_HPP
 #define CHANNEL_HPP
-#include "Server.hpp"
 #include <algorithm>
+#include <Client.hpp>
+#include <sstream>
 
 class Channel
 {
@@ -48,6 +49,8 @@ class Channel
 		// void	broadcast(const std::string& msg, const Client* except = NULL);
 		std::string getModeString(void) const;
 		std::string buildNamesReply(void) const;
+
+		std::string getName(void) const;
 };
 
 #endif // CHANNEL_HPP

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -6,7 +6,7 @@
 /*   By: ekeisler <ekeisler@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/22 16:27:59 by lcalero           #+#    #+#             */
-/*   Updated: 2026/04/27 18:29:08 by jaubry--         ###   ########.fr       */
+/*   Updated: 2026/04/28 02:08:44 by jaubry--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 #define SERVER_HPP
 
 #include "Client.hpp"
+#include "Channel.hpp"
 #include "utils.hpp"
 #include <arpa/inet.h>
 #include <cerrno>
@@ -51,6 +52,11 @@ class Server
 		void	   start(void);
 		bool	   isPasswordValid(const std::string& password);
 
+		Client*    getClientByFd(const int fd) const;
+		Client*    getClientByNick(const std::string& name) const;
+		Channel*   getChannelByName(const std::string& name) const;
+		Channel*   getOrCreateChannel(const std::string& name);
+
 	private:
 		enum ReadStatus
 		{
@@ -60,11 +66,14 @@ class Server
 			READ_ERROR
 		};
 
-		int					 _epoll_fd;
-		int					 _listen_sock;
-		int					 _port;
-		const std::string	 _password;
-		std::vector<Client*> _clients;
+		const std::string	  _serverName;
+		const std::string	  _creationDate;
+		int					  _epoll_fd;
+		int					  _listen_sock;
+		int					  _port;
+		const std::string	  _password;
+		std::vector<Client*>  _clients;
+		std::vector<Channel*> _channels;
 
 		static Server* _instance;
 

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -13,8 +13,8 @@
 #ifndef SERVER_HPP
 #define SERVER_HPP
 
-#include "Client.hpp"
 #include "Channel.hpp"
+#include "Client.hpp"
 #include "utils.hpp"
 #include <arpa/inet.h>
 #include <cerrno>
@@ -52,10 +52,10 @@ class Server
 		void	   start(void);
 		bool	   isPasswordValid(const std::string& password);
 
-		Client*    getClientByFd(const int fd) const;
-		Client*    getClientByNick(const std::string& name) const;
-		Channel*   getChannelByName(const std::string& name) const;
-		Channel*   getOrCreateChannel(const std::string& name);
+		Client*	 getClientByFd(const int fd) const;
+		Client*	 getClientByNick(const std::string& name) const;
+		Channel* getChannelByName(const std::string& name) const;
+		Channel* getOrCreateChannel(const std::string& name);
 
 	private:
 		enum ReadStatus

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -6,7 +6,7 @@
 /*   By: jaubry-- <jaubry--@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/25 02:44:21 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/25 02:44:52 by jaubry--         ###   ########.fr       */
+/*   Updated: 2026/04/28 01:48:50 by jaubry--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,6 +40,8 @@ struct HasMemberValue
 		HasMemberValue(Getter getter, ReturnType expected);
 		bool operator()(const ClassType* obj) const;
 };
+
+std::string getCurrentTime(void);
 
 }
 

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/27 21:01:11 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/27 23:58:33 by jaubry--         ###   ########.fr       */
+/*   Updated: 2026/04/28 02:09:58 by jaubry--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,11 @@ Channel::addMember(const Client& client)
 	{
 		if ((this->_userLimit == 0)
 			|| (this->_userLimit > this->_members.size()))
+		{
+			if (this->_members.size() == 0)
+				this->addOperator(client);
 			this->_members.push_back(const_cast<Client*>(&client));
+		}
 		else
 			std::cout << "no more place inside channel\n";
 	}
@@ -147,4 +151,10 @@ Channel::buildNamesReply(void) const
 	}
 
 	return (names);
+}
+
+std::string
+Channel::getName(void) const
+{
+	return (this->_name);
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -253,10 +253,10 @@ Server::removeClient(int fd)
 Client*
 Server::getClientByFd(const int fd) const
 {
-	std::vector<Client*>::const_iterator it = std::find_if(
-			this->_clients.begin(),
-			this->_clients.end(),
-			utils::HasMemberValue<Client, int>(&Client::getFd, fd));
+	std::vector<Client*>::const_iterator it =
+		std::find_if(this->_clients.begin(),
+					 this->_clients.end(),
+					 utils::HasMemberValue<Client, int>(&Client::getFd, fd));
 	if (it == this->_clients.end())
 		return (NULL);
 	return (*it);
@@ -266,9 +266,9 @@ Client*
 Server::getClientByNick(const std::string& nick) const
 {
 	std::vector<Client*>::const_iterator it = std::find_if(
-			this->_clients.begin(),
-			this->_clients.end(),
-			utils::HasMemberValue<Client, std::string>(&Client::getNickname, nick));
+		this->_clients.begin(),
+		this->_clients.end(),
+		utils::HasMemberValue<Client, std::string>(&Client::getNickname, nick));
 	if (it == this->_clients.end())
 		return (NULL);
 	return (*it);
@@ -278,9 +278,9 @@ Channel*
 Server::getChannelByName(const std::string& name) const
 {
 	std::vector<Channel*>::const_iterator it = std::find_if(
-			this->_channels.begin(),
-			this->_channels.end(),
-			utils::HasMemberValue<Channel, std::string>(&Channel::getName, name));
+		this->_channels.begin(),
+		this->_channels.end(),
+		utils::HasMemberValue<Channel, std::string>(&Channel::getName, name));
 	if (it == this->_channels.end())
 		return (NULL);
 	return (*it);
@@ -289,7 +289,7 @@ Server::getChannelByName(const std::string& name) const
 Channel*
 Server::getOrCreateChannel(const std::string& name)
 {
-	Channel	*channel;
+	Channel* channel;
 
 	channel = this->getChannelByName(name);
 	if (channel == NULL)
@@ -325,7 +325,7 @@ Server::handleEvents(struct epoll_event events[MAX_EVENTS], int nfds)
 				removeClient(fd);
 				continue;
 			}
-			
+
 			Client* client = this->getClientByFd(fd);
 			if (client == NULL)
 				continue;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: lcalero <lcalero@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/22 16:52:35 by lcalero           #+#    #+#             */
-/*   Updated: 2026/04/27 18:26:03 by jaubry--         ###   ########.fr       */
+/*   Updated: 2026/04/28 02:18:20 by jaubry--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,11 +53,14 @@ Server::destroy(void)
 }
 
 Server::Server(int port, const std::string& password) :
+	_serverName("ft_irc.42lyon.fr"),
+	_creationDate(utils::getCurrentTime()),
 	_epoll_fd(-1),
 	_listen_sock(-1),
 	_port(port),
 	_password(password),
-	_clients()
+	_clients(),
+	_channels()
 {
 	// logging
 	LOG_INFO(this->_port);
@@ -81,6 +84,11 @@ Server::~Server(void)
 	// deleting client pointers
 	for (std::vector<Client*>::const_iterator i = this->_clients.begin();
 		 i != this->_clients.end();
+		 ++i)
+		delete (*i);
+	// deleting channels pointers
+	for (std::vector<Channel*>::const_iterator i = this->_channels.begin();
+		 i != this->_channels.end();
 		 ++i)
 		delete (*i);
 }
@@ -242,6 +250,56 @@ Server::removeClient(int fd)
 	return (true);
 }
 
+Client*
+Server::getClientByFd(const int fd) const
+{
+	std::vector<Client*>::const_iterator it = std::find_if(
+			this->_clients.begin(),
+			this->_clients.end(),
+			utils::HasMemberValue<Client, int>(&Client::getFd, fd));
+	if (it == this->_clients.end())
+		return (NULL);
+	return (*it);
+}
+
+Client*
+Server::getClientByNick(const std::string& nick) const
+{
+	std::vector<Client*>::const_iterator it = std::find_if(
+			this->_clients.begin(),
+			this->_clients.end(),
+			utils::HasMemberValue<Client, std::string>(&Client::getNickname, nick));
+	if (it == this->_clients.end())
+		return (NULL);
+	return (*it);
+}
+
+Channel*
+Server::getChannelByName(const std::string& name) const
+{
+	std::vector<Channel*>::const_iterator it = std::find_if(
+			this->_channels.begin(),
+			this->_channels.end(),
+			utils::HasMemberValue<Channel, std::string>(&Channel::getName, name));
+	if (it == this->_channels.end())
+		return (NULL);
+	return (*it);
+}
+
+Channel*
+Server::getOrCreateChannel(const std::string& name)
+{
+	Channel	*channel;
+
+	channel = this->getChannelByName(name);
+	if (channel == NULL)
+	{
+		channel = new Channel(name);
+		this->_channels.push_back(channel);
+	}
+	return (channel);
+}
+
 /* This function handles all the events received in a loop iterating
 over all the events received and deciding logic to adapt according
 to what it has received */
@@ -267,24 +325,21 @@ Server::handleEvents(struct epoll_event events[MAX_EVENTS], int nfds)
 				removeClient(fd);
 				continue;
 			}
-			std::vector<Client*>::iterator it = std::find_if(
-				this->_clients.begin(),
-				this->_clients.end(),
-				utils::HasMemberValue<Client, int>(&Client::getFd, fd));
-
-			if (it == this->_clients.end())
+			
+			Client* client = this->getClientByFd(fd);
+			if (client == NULL)
 				continue;
 
-			(*it)->appendToBuffer(std::string(buffer, n));
+			client->appendToBuffer(std::string(buffer, n));
 
-			std::vector<std::string> messages = (*it)->extractMessages();
+			std::vector<std::string> messages = client->extractMessages();
 
 			CommandDispatcher disp;
 			CommandParser	  parser(disp);
 			try
 			{
 				for (size_t j = 0; j < messages.size(); j++)
-					parser.parse(**it, messages[j]);
+					parser.parse(*client, messages[j]);
 			}
 			catch (const std::exception& e)
 			{

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -12,9 +12,9 @@
 
 #include "utils.hpp"
 
+#include <ctime>
 #include <iomanip>
 #include <sstream>
-#include <ctime>
 
 namespace utils
 {
@@ -102,8 +102,8 @@ ft_atou(const std::string& str, int& num)
 std::string
 getCurrentTime(void)
 {
-	time_t now = time(NULL);
-	std::string t = ctime(&now);
+	time_t		now = time(NULL);
+	std::string t	= ctime(&now);
 	t.erase(t.find_last_not_of("\n\r") + 1);
 	return (t);
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6,7 +6,7 @@
 /*   By: jaubry-- <jaubry--@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/25 02:46:19 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/25 02:50:04 by jaubry--         ###   ########.fr       */
+/*   Updated: 2026/04/28 02:14:28 by jaubry--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 
 #include <iomanip>
 #include <sstream>
+#include <ctime>
 
 namespace utils
 {
@@ -96,5 +97,14 @@ ft_atou(const std::string& str, int& num)
 		throw std::overflow_error("Input overflows int");
 
 	num = static_cast<int>(tmp);
+}
+
+std::string
+getCurrentTime(void)
+{
+	time_t now = time(NULL);
+	std::string t = ctime(&now);
+	t.erase(t.find_last_not_of("\n\r") + 1);
+	return (t);
 }
 }


### PR DESCRIPTION
## Summary
Implements the `Server` class members required for runtime state management: channel ownership, server identity fields, and all lookup/lifecycle methods. Also adds supporting utilities (`getCurrentTime`) and the missing getter on `Channel`.

## Why
The `Server` class is the single owner of all runtime state — no command handler, event loop, or registration flow can be wired up without it. `_serverName` and `_creationDate` are required by the subject for `RPL_YOURHOST (002)`, `RPL_CREATED (003)`, and `RPL_MYINFO (004)`. The single `poll()` constraint from the subject mandates a unified `_pollfds` array managed entirely by `Server`.

## Changes
- Add `_serverName` (hardcoded) and `_creationDate` (captured via `getCurrentTime()`) initialised in constructor
- Add `getCurrentTime()` helper in `utils` namespace returning the current time as a formatted `std::string`
- Add `_channels` as `std::vector<Channel*>` with `getChannelByName`, `getOrCreateChannel`
- Add `getClientByNick` with `const_iterator` to match `const` method correctness
- Fix `getClientByFd`, `getClientByNick`, `getChannelByName` to use `const_iterator` in `const` methods
- Add to destructor deleting all `Channel*`
- Add `getName` on `Channel`
- Replace `Server.hpp` include with necessary `Client.hpp` in `Channel.hpp` instead to fix circular include
