### PR TITLE
task/113-Implement-PongCommand

### DIFF
--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -6,7 +6,7 @@
 /*   By: ekeisler <ekeisler@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/23 17:08:01 by lcalero           #+#    #+#             */
-/*   Updated: 2026/04/28 17:53:31 by ekeisler         ###   ########.fr       */
+/*   Updated: 2026/04/29 00:37:01 by ekeisler         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,6 +54,7 @@ class Client
 		void					 setRealName(const std::string& realname);
 		void					 setHostName(const std::string& hostname);
 		void					 setRegistered(bool registered);
+		void					 reply(const std::string& msg);
 
 		std::string getNickname(void) const;
 		std::string getUsername(void) const;

--- a/include/commands/CommandDispatcher.hpp
+++ b/include/commands/CommandDispatcher.hpp
@@ -20,8 +20,8 @@
 #include "JoinCommand.hpp"
 #include "PrivmsgCommand.hpp"
 
-#include "PongCommand.hpp"
 #include "CapCommand.hpp"
+#include "PongCommand.hpp"
 
 #include "InviteCommand.hpp"
 #include "KickCommand.hpp"

--- a/include/commands/CommandDispatcher.hpp
+++ b/include/commands/CommandDispatcher.hpp
@@ -6,7 +6,7 @@
 /*   By: ekeisler <ekeisler@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/23 16:24:50 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/27 18:09:37 by ekeisler         ###   ########.fr       */
+/*   Updated: 2026/04/29 00:39:16 by ekeisler         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,9 @@
 
 #include "JoinCommand.hpp"
 #include "PrivmsgCommand.hpp"
+
+#include "PongCommand.hpp"
+#include "CapCommand.hpp"
 
 #include "InviteCommand.hpp"
 #include "KickCommand.hpp"

--- a/include/commands/channel/PongCommand.hpp
+++ b/include/commands/channel/PongCommand.hpp
@@ -1,0 +1,33 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   PongCommand.hpp                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ekeisler <ekeisler@student.42lyon.fr>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/04/29 00:26:11 by ekeisler          #+#    #+#             */
+/*   Updated: 2026/04/29 00:37:57 by ekeisler         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef PONGCOMMAND_HPP
+#define PONGCOMMAND_HPP
+
+#include "ACommand.hpp"
+
+class PongCommand : public ACommand
+{
+	private:
+		PongCommand(void);
+		PongCommand(const PongCommand& other);
+		PongCommand& operator=(const PongCommand& other);
+
+	public:
+		static const std::string NAME; // = "PASS"
+
+		// PASS <password>
+		static void execute(Client&							client,
+							const std::vector<std::string>& args);
+};
+
+#endif

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -6,11 +6,12 @@
 /*   By: ekeisler <ekeisler@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/23 17:14:10 by lcalero           #+#    #+#             */
-/*   Updated: 2026/04/28 17:56:24 by ekeisler         ###   ########.fr       */
+/*   Updated: 2026/04/29 00:54:44 by ekeisler         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Client.hpp"
+#include <sys/socket.h>
 #include <unistd.h>
 
 Client::Client(int fd, std::string hostname) :
@@ -82,6 +83,13 @@ Client::extractMessages()
 		this->_inputBuffer.erase(0, pos + 1);
 	}
 	return (messages);
+}
+
+void
+Client::reply(const std::string& msg)
+{
+    if (send(this->_fd, msg.c_str(), msg.size(), 0) == -1)
+        std::cerr << "send() failed for client " << _nickname << std::endl;
 }
 
 int

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -6,7 +6,7 @@
 /*   By: ekeisler <ekeisler@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/23 17:14:10 by lcalero           #+#    #+#             */
-/*   Updated: 2026/04/29 00:54:44 by ekeisler         ###   ########.fr       */
+/*   Updated: 2026/04/29 01:35:23 by ekeisler         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -88,8 +88,12 @@ Client::extractMessages()
 void
 Client::reply(const std::string& msg)
 {
-    if (send(this->_fd, msg.c_str(), msg.size(), 0) == -1)
-        std::cerr << "send() failed for client " << _nickname << std::endl;
+	ssize_t sent = send(this->getFd(), msg.c_str(), msg.size(), 0);
+
+	if (sent == -1)
+		std::cout << "send(): failed" << std::endl;
+	else if (sent < static_cast<ssize_t>(msg.size()))
+		std::cout << "send(): message partially sent" << std::endl;
 }
 
 int

--- a/src/commands/CommandDispatcher.cpp
+++ b/src/commands/CommandDispatcher.cpp
@@ -6,12 +6,11 @@
 /*   By: ekeisler <ekeisler@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/23 17:11:23 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/28 22:16:12 by ekeisler         ###   ########.fr       */
+/*   Updated: 2026/04/29 00:56:59 by ekeisler         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "CommandDispatcher.hpp"
-#include "CapCommand.hpp"
 #include "utils.hpp"
 #include <iostream>
 #include <stdexcept>
@@ -22,6 +21,7 @@ CommandDispatcher::CommandDispatcher(void)
 	registerCommand(NickCommand::NAME, &NickCommand::execute);
 	registerCommand(CapCommand::NAME, &CapCommand::execute);
 	registerCommand(UserCommand::NAME, &UserCommand::execute);
+	registerCommand(PongCommand::NAME, &PongCommand::execute);
 	/*
 	registerCommand(JoinCommand::NAME, &JoinCommand::execute);
 	registerCommand(PrivmsgCommand::NAME, &PrivmsgCommand::execute);

--- a/src/commands/auth/UserCommand.cpp
+++ b/src/commands/auth/UserCommand.cpp
@@ -6,7 +6,7 @@
 /*   By: ekeisler <ekeisler@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/23 21:31:47 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/28 21:40:35 by ekeisler         ###   ########.fr       */
+/*   Updated: 2026/04/29 00:52:44 by ekeisler         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,8 @@ const std::string UserCommand::NAME = "USER";
 void
 UserCommand::execute(Client& client, const std::vector<std::string>& args)
 {
+	std::cout << "LETS GO" << std::endl;
+
 	if (client.getRegistered())
 	{
 		// send ERR_ALREADYREGISTRED 462

--- a/src/commands/auth/UserCommand.cpp
+++ b/src/commands/auth/UserCommand.cpp
@@ -6,7 +6,7 @@
 /*   By: ekeisler <ekeisler@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/23 21:31:47 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/29 00:52:44 by ekeisler         ###   ########.fr       */
+/*   Updated: 2026/04/29 02:30:40 by ekeisler         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,8 +17,6 @@ const std::string UserCommand::NAME = "USER";
 void
 UserCommand::execute(Client& client, const std::vector<std::string>& args)
 {
-	std::cout << "LETS GO" << std::endl;
-
 	if (client.getRegistered())
 	{
 		// send ERR_ALREADYREGISTRED 462

--- a/src/commands/channel/PongCommand.cpp
+++ b/src/commands/channel/PongCommand.cpp
@@ -1,0 +1,24 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   PongCommand.cpp                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ekeisler <ekeisler@student.42lyon.fr>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/04/29 00:28:32 by ekeisler          #+#    #+#             */
+/*   Updated: 2026/04/29 00:41:31 by ekeisler         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "PongCommand.hpp"
+
+const std::string PongCommand::NAME = "PING";
+
+void
+PongCommand::execute(Client& client, const std::vector<std::string>& args)
+{
+	// ERR_NOORIGIN (409) — no server token provided
+	if (args.empty())
+        return;
+	client.reply("PONG " + args[0] + "\r\n");
+}

--- a/src/commands/channel/PongCommand.cpp
+++ b/src/commands/channel/PongCommand.cpp
@@ -19,6 +19,6 @@ PongCommand::execute(Client& client, const std::vector<std::string>& args)
 {
 	// ERR_NOORIGIN (409) — no server token provided
 	if (args.empty())
-        return;
+		return;
 	client.reply("PONG " + args[0] + "\r\n");
 }

--- a/src/commands/channel/channel.mk
+++ b/src/commands/channel/channel.mk
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    channel.mk                                         :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+         #
+#    By: ekeisler <ekeisler@student.42lyon.fr>      +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2026/04/23 17:32:03 by jaubry--          #+#    #+#              #
-#    Updated: 2026/04/23 17:33:08 by jaubry--         ###   ########.fr        #
+#    Updated: 2026/04/29 00:40:13 by ekeisler         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -15,7 +15,8 @@ CHANNEL_DIR      = $(COMMANDS_DIR)/channel
 
 # Source files
 CHANNEL_SRCS     = JoinCommand.cpp \
-				   PrivmsgCommand.cpp
+				   PrivmsgCommand.cpp \
+				   PongCommand.cpp
 
 SRCS            += $(addprefix $(CHANNEL_DIR)/, $(CHANNEL_SRCS))
 


### PR DESCRIPTION
## Summary

Implement the `PING` command so the server replies with `PONG` to keep connections alive.

## Changes
- Implement `PingCommand::execute()`:
  - Replies with `PONG <token>` echoing the argument sent by the client

## Tests
- [x] Code compiles with `-Wall -Wextra -Werror -std=c++98`, no warnings
- [x] Manual test with `nc -C 127.0.0.1 6667` — send `PING :test` and verify `PONG :test` is received
- [x] Manual test with irssi — `[Lag: ?? (??)]` no longer appears in the status bar after connecting
- [x] `PING` sent before registration completes is handled correctly

## Risks

None — this is a stateless, read-and-reply command with no side effects.

## Linked issue
Closes #113 

---

## Merge policy

- Use squash or rebase merges only (no merge commits).
- Ensure dependancy are merged and there's no `blocked` label
- Do not merge if any CI check is red.
- Do not merge without at least one review approval.
- Ensure the branch is up to date with main before merging.
