### PR TITLE
Task/72 implement channel MODE command and channel mode state updates

### DIFF
--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -6,7 +6,7 @@
 /*   By: lcalero <lcalero@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/27 21:00:50 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/29 02:21:44 by jaubry--         ###   ########.fr       */
+/*   Updated: 2026/04/30 05:02:45 by jaubry--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,6 +57,16 @@ class Channel
 		std::string getTopic(void) const;
 
 		unsigned int getUserLimit(void) const;
+		void setUserLimit(unsigned int);
+
+		bool getInviteMode(void) const;
+		void setInviteMode(bool);
+		
+		bool getTopicMode(void) const;
+		void setTopicMode(bool);
+
+		void setKey(const std::string& newKey);
+
 		std::size_t	 getMemberSize(void) const;
 
 		bool isValidKey(const std::string& key) const;

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -57,17 +57,17 @@ class Channel
 		std::string getTopic(void) const;
 
 		unsigned int getUserLimit(void) const;
-		void setUserLimit(unsigned int);
+		void		 setUserLimit(unsigned int);
 
 		bool getInviteMode(void) const;
 		void setInviteMode(bool);
-		
+
 		bool getTopicMode(void) const;
 		void setTopicMode(bool);
 
 		void setKey(const std::string& newKey);
 
-		std::size_t	 getMemberSize(void) const;
+		std::size_t getMemberSize(void) const;
 
 		bool isValidKey(const std::string& key) const;
 

--- a/include/commands/operator/ModeCommand.hpp
+++ b/include/commands/operator/ModeCommand.hpp
@@ -6,7 +6,7 @@
 /*   By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/23 16:25:57 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/23 22:51:20 by jaubry--         ###   ########.fr       */
+/*   Updated: 2026/04/30 05:11:14 by jaubry--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 
-typedef void (*ModeHandler)(const std::string&				channel,
+typedef void (*ModeHandler)(Client& client, Channel& channel,
 							const std::vector<std::string>& args);
 
 class ModeCommand : public ACommand
@@ -29,32 +29,28 @@ class ModeCommand : public ACommand
 		ModeCommand& operator=(const ModeCommand& other);
 		static std::map<std::string, ModeHandler>& getHandlers(void);
 
-		static void modeInviteOn(const std::string&				 channel,
+		static void modeInvite(Client& client, Channel& channel,
 								 const std::vector<std::string>& args);
-		static void modeInviteOff(const std::string&			  channel,
-								  const std::vector<std::string>& args);
-		static void modeTopicOn(const std::string&				channel,
+		static void modeTopic(Client& client, Channel& channel,
 								const std::vector<std::string>& args);
-		static void modeTopicOff(const std::string&				 channel,
-								 const std::vector<std::string>& args);
-		static void modeKeyOn(const std::string&			  channel,
+		static void modeKeyOn(Client& client, Channel& channel,
 							  const std::vector<std::string>& args);
-		static void modeKeyOff(const std::string&			   channel,
+		static void modeKeyOff(Client& client, Channel& channel,
 							   const std::vector<std::string>& args);
-		static void modeOpOn(const std::string&				 channel,
+		static void modeOpOn(Client& client, Channel& channel,
 							 const std::vector<std::string>& args);
-		static void modeOpOff(const std::string&			  channel,
+		static void modeOpOff(Client& client, Channel& channel,
 							  const std::vector<std::string>& args);
-		static void modeLimitOn(const std::string&				channel,
+		static void modeLimitOn(Client& client, Channel& channel,
 								const std::vector<std::string>& args);
-		static void modeLimitOff(const std::string&				 channel,
+		static void modeLimitOff(Client& client, Channel& channel,
 								 const std::vector<std::string>& args);
 
 	public:
 		static const std::string NAME; // = "MODE"
 
 		// MODE <username>
-		static void execute(const std::vector<std::string>& args);
+		static void execute(Client& client, const std::vector<std::string>& args);
 };
 
 #endif // MODE_COMMAND_HPP

--- a/include/commands/operator/ModeCommand.hpp
+++ b/include/commands/operator/ModeCommand.hpp
@@ -18,7 +18,8 @@
 #include <string>
 #include <vector>
 
-typedef void (*ModeHandler)(Client& client, Channel& channel,
+typedef void (*ModeHandler)(Client&							client,
+							Channel&						channel,
 							const std::vector<std::string>& args);
 
 class ModeCommand : public ACommand
@@ -29,28 +30,37 @@ class ModeCommand : public ACommand
 		ModeCommand& operator=(const ModeCommand& other);
 		static std::map<std::string, ModeHandler>& getHandlers(void);
 
-		static void modeInvite(Client& client, Channel& channel,
-								 const std::vector<std::string>& args);
-		static void modeTopic(Client& client, Channel& channel,
-								const std::vector<std::string>& args);
-		static void modeKeyOn(Client& client, Channel& channel,
-							  const std::vector<std::string>& args);
-		static void modeKeyOff(Client& client, Channel& channel,
+		static void modeInvite(Client&						   client,
+							   Channel&						   channel,
 							   const std::vector<std::string>& args);
-		static void modeOpOn(Client& client, Channel& channel,
-							 const std::vector<std::string>& args);
-		static void modeOpOff(Client& client, Channel& channel,
+		static void modeTopic(Client&						  client,
+							  Channel&						  channel,
 							  const std::vector<std::string>& args);
-		static void modeLimitOn(Client& client, Channel& channel,
+		static void modeKeyOn(Client&						  client,
+							  Channel&						  channel,
+							  const std::vector<std::string>& args);
+		static void modeKeyOff(Client&						   client,
+							   Channel&						   channel,
+							   const std::vector<std::string>& args);
+		static void modeOpOn(Client&						 client,
+							 Channel&						 channel,
+							 const std::vector<std::string>& args);
+		static void modeOpOff(Client&						  client,
+							  Channel&						  channel,
+							  const std::vector<std::string>& args);
+		static void modeLimitOn(Client&							client,
+								Channel&						channel,
 								const std::vector<std::string>& args);
-		static void modeLimitOff(Client& client, Channel& channel,
+		static void modeLimitOff(Client&						 client,
+								 Channel&						 channel,
 								 const std::vector<std::string>& args);
 
 	public:
 		static const std::string NAME; // = "MODE"
 
 		// MODE <username>
-		static void execute(Client& client, const std::vector<std::string>& args);
+		static void execute(Client&							client,
+							const std::vector<std::string>& args);
 };
 
 #endif // MODE_COMMAND_HPP

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: lcalero <lcalero@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/27 21:01:11 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/29 02:26:40 by jaubry--         ###   ########.fr       */
+/*   Updated: 2026/04/30 05:23:43 by jaubry--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -184,6 +184,42 @@ unsigned int
 Channel::getUserLimit(void) const
 {
 	return (this->_userLimit);
+}
+
+void
+Channel::setUserLimit(unsigned int limit)
+{
+	this->_userLimit = limit;
+}
+
+bool
+Channel::getInviteMode(void) const
+{
+	return (this->_inviteOnly);
+}
+
+void
+Channel::setInviteMode(bool mode)
+{
+	this->_inviteOnly = mode;
+}
+
+bool
+Channel::getTopicMode(void) const
+{
+	return (this->_topicRestricted);
+}
+
+void
+Channel::setTopicMode(bool mode)
+{
+	this->_topicRestricted = mode;
+}
+
+void
+Channel::setKey(const std::string& newKey)
+{
+	this->_key = newKey;
 }
 
 std::size_t

--- a/src/commands/CommandDispatcher.cpp
+++ b/src/commands/CommandDispatcher.cpp
@@ -6,7 +6,7 @@
 /*   By: ekeisler <ekeisler@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/23 17:11:23 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/29 02:40:09 by ekeisler         ###   ########.fr       */
+/*   Updated: 2026/04/30 02:44:30 by jaubry--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,12 +24,10 @@ CommandDispatcher::CommandDispatcher(void)
 	registerCommand(PongCommand::NAME, &PongCommand::execute);
 	registerCommand(JoinCommand::NAME, &JoinCommand::execute);
 	registerCommand(PrivmsgCommand::NAME, &PrivmsgCommand::execute);
-
+	registerCommand(ModeCommand::NAME, &ModeCommand::execute);
 	/*
-	registerCommand(JoinCommand::NAME, &JoinCommand::execute);
 	registerCommand(InviteCommand::NAME, &InviteCommand::execute);
 	registerCommand(KickCommand::NAME, &KickCommand::execute);
-	registerCommand(ModeCommand::NAME, &ModeCommand::execute);
 	registerCommand(TopicCommand::NAME, &TopicCommand::execute);
 	*/
 }

--- a/src/commands/operator/ModeCommand.cpp
+++ b/src/commands/operator/ModeCommand.cpp
@@ -6,8 +6,195 @@
 /*   By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/23 22:12:43 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/24 19:45:06 by jaubry--         ###   ########.fr       */
+/*   Updated: 2026/04/30 05:20:05 by jaubry--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "ModeCommand.hpp"
+#include "ServerReply.hpp"
+
+const std::string ModeCommand::NAME = "MODE";
+
+void
+ModeCommand::execute(Client& client, const std::vector<std::string>& args)
+{
+	requireArgsNum(args, 1, 3, "MODE #<channel> <mode>");
+	requireChannel(args, 0, "channel name");
+	Channel* chan = Server::getInstance()->getChannelByName(args[0]);
+	if (!chan)
+	{
+		ServerReply::reply(client, ServerReply::ERR_NOSUCHCHANNEL, args[0]);
+		return ;
+	}
+
+	if (args.size() > 1)
+	{
+		if (chan->isOperator(client))
+		{
+			requireMode(args, 1, "channel mode");
+			getHandlers()[args[1]](client, *chan, args);
+		}
+		else
+			ServerReply::reply(client, *chan, ServerReply::ERR_CHANOPRIVSNEEDED);
+	}
+	else
+		ServerReply::reply(client, *chan, ServerReply::RPL_CHANNELMODEIS);
+}
+
+std::map<std::string, ModeHandler>&
+ModeCommand::getHandlers(void)
+{
+	static std::map<std::string, ModeHandler> handlers;
+	if (handlers.empty())
+	{
+		handlers["+i"] = &ModeCommand::modeInvite;
+		handlers["-i"] = &ModeCommand::modeInvite;
+		handlers["+t"] = &ModeCommand::modeTopic;
+		handlers["-t"] = &ModeCommand::modeTopic;
+		handlers["+k"] = &ModeCommand::modeKeyOn;
+		handlers["-k"] = &ModeCommand::modeKeyOff;
+		handlers["+o"] = &ModeCommand::modeOpOn;
+		handlers["-o"] = &ModeCommand::modeOpOff;
+		handlers["+l"] = &ModeCommand::modeLimitOn;
+		handlers["-l"] = &ModeCommand::modeLimitOff;
+	}
+	return (handlers);
+}
+
+static void
+printMode(Channel& channel,
+		  const std::string& mode,
+		  const std::string& action,
+		  const std::string& param = "")
+{
+	std::cout << "MODE " << channel.getName() << " " << mode << " | " << action
+			  << (param.empty() ? "" : " [" + param + "]") << std::endl;
+}
+
+void
+ModeCommand::modeInvite(Client& client, Channel& chan,
+						  const std::vector<std::string>& args)
+{
+	(void)client;
+	requireArgsNum(args, 2, "MODE #<channel> <mode>");
+	chan.setInviteMode(args[1][0] == '+');
+	if (DEBUG)
+	{
+		if (chan.getInviteMode())
+			printMode(chan, "+i", "Set invite-only");
+		else
+			printMode(chan, "-i", "Removed invite-only");
+	}
+	
+}
+
+void
+ModeCommand::modeTopic(Client& client, Channel& chan,
+						 const std::vector<std::string>& args)
+{
+	(void)client;
+	requireArgsNum(args, 2, "MODE #<channel> <mode>");
+	chan.setTopicMode(args[1][0] == '+');
+	if (DEBUG)
+	{
+		if (chan.getTopicMode())
+			printMode(chan, "+t", "Restricted TOPIC to operators");
+		else
+			printMode(chan, "-t", "Removed TOPIC restriction");
+	}
+}
+
+void
+ModeCommand::modeKeyOn(Client& client, Channel& chan,
+					   const std::vector<std::string>& args)
+{
+	(void)client;
+	requireArgsNum(args, 3, "MODE #<channel> <mode> <password>");
+	requireWord(args, 2, "new password");
+	chan.setKey(args[2]);
+	if (DEBUG)
+		printMode(chan, "+k", "Set password", args[2]);
+}
+
+void
+ModeCommand::modeKeyOff(Client& client, Channel& chan,
+						const std::vector<std::string>& args)
+{
+	(void)client;
+	requireArgsNum(args, 2, "MODE #<channel> <mode>");
+	chan.setKey("");
+	if (DEBUG)
+		printMode(chan, "-k", "Removed password");
+}
+
+void
+ModeCommand::modeOpOn(Client& client, Channel& chan,
+					  const std::vector<std::string>& args)
+{
+	requireArgsNum(args, 3, "MODE #<channel> <othernick>");
+	requireWord(args, 2, "target nickname");
+	if (client.getNickname() != args[2])
+	{
+		Client* target = Server::getInstance()->getClientByNick(args[2]);
+		if (target)
+		{
+			if (!chan.isOperator(*target))
+			{
+				chan.addOperator(*target);
+				if (DEBUG)
+					printMode(chan, "+o", "Gave operator to", args[2]);
+			}
+		}
+		else
+			ServerReply::reply(client, ServerReply::ERR_NOSUCHNICK, args[2]);
+	}
+}
+
+void
+ModeCommand::modeOpOff(Client& client, Channel& chan,
+					   const std::vector<std::string>& args)
+{
+	requireArgsNum(args, 3, "MODE #<channel> <othernick>");
+	requireWord(args, 2, "target nickname");
+	if (client.getNickname() != args[2])
+	{
+		Client* target = Server::getInstance()->getClientByNick(args[2]);
+		if (target)
+		{
+			if (chan.isOperator(*target))
+			{
+				chan.removeOperator(*target);
+				if (DEBUG)
+					printMode(chan, "-o", "Removed operator from", args[2]);
+			}
+		}
+		else
+			ServerReply::reply(client, ServerReply::ERR_NOSUCHNICK, args[2]);
+	}
+}
+
+void
+ModeCommand::modeLimitOn(Client& client, Channel& chan,
+						 const std::vector<std::string>& args)
+{
+	(void)client;
+	requireArgsNum(args, 3, "MODE #<channel> <positive_int>");
+	requirePosInt(args, 2, "channel limit");
+
+	int limit;
+	utils::ft_atou(args[2], limit);
+	chan.setUserLimit(limit);
+	if (DEBUG)
+		printMode(chan, "+l", "Set user limit", args[2]);
+}
+
+void
+ModeCommand::modeLimitOff(Client& client, Channel& chan,
+						  const std::vector<std::string>& args)
+{
+	(void)client;
+	requireArgsNum(args, 2, "MODE #<channel>");
+	if (DEBUG)
+		printMode(chan, "-l", "Removed user limit");
+	chan.setUserLimit(0);
+}

--- a/src/commands/operator/ModeCommand.cpp
+++ b/src/commands/operator/ModeCommand.cpp
@@ -6,7 +6,7 @@
 /*   By: jaubry-- <jaubry--@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/23 22:12:43 by jaubry--          #+#    #+#             */
-/*   Updated: 2026/04/30 05:20:05 by jaubry--         ###   ########.fr       */
+/*   Updated: 2026/04/30 05:33:08 by jaubry--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ ModeCommand::execute(Client& client, const std::vector<std::string>& args)
 	if (!chan)
 	{
 		ServerReply::reply(client, ServerReply::ERR_NOSUCHCHANNEL, args[0]);
-		return ;
+		return;
 	}
 
 	if (args.size() > 1)
@@ -35,7 +35,8 @@ ModeCommand::execute(Client& client, const std::vector<std::string>& args)
 			getHandlers()[args[1]](client, *chan, args);
 		}
 		else
-			ServerReply::reply(client, *chan, ServerReply::ERR_CHANOPRIVSNEEDED);
+			ServerReply::reply(
+				client, *chan, ServerReply::ERR_CHANOPRIVSNEEDED);
 	}
 	else
 		ServerReply::reply(client, *chan, ServerReply::RPL_CHANNELMODEIS);
@@ -62,7 +63,7 @@ ModeCommand::getHandlers(void)
 }
 
 static void
-printMode(Channel& channel,
+printMode(const Channel&	 channel,
 		  const std::string& mode,
 		  const std::string& action,
 		  const std::string& param = "")
@@ -72,8 +73,9 @@ printMode(Channel& channel,
 }
 
 void
-ModeCommand::modeInvite(Client& client, Channel& chan,
-						  const std::vector<std::string>& args)
+ModeCommand::modeInvite(Client&							client,
+						Channel&						chan,
+						const std::vector<std::string>& args)
 {
 	(void)client;
 	requireArgsNum(args, 2, "MODE #<channel> <mode>");
@@ -85,12 +87,12 @@ ModeCommand::modeInvite(Client& client, Channel& chan,
 		else
 			printMode(chan, "-i", "Removed invite-only");
 	}
-	
 }
 
 void
-ModeCommand::modeTopic(Client& client, Channel& chan,
-						 const std::vector<std::string>& args)
+ModeCommand::modeTopic(Client&						   client,
+					   Channel&						   chan,
+					   const std::vector<std::string>& args)
 {
 	(void)client;
 	requireArgsNum(args, 2, "MODE #<channel> <mode>");
@@ -105,7 +107,8 @@ ModeCommand::modeTopic(Client& client, Channel& chan,
 }
 
 void
-ModeCommand::modeKeyOn(Client& client, Channel& chan,
+ModeCommand::modeKeyOn(Client&						   client,
+					   Channel&						   chan,
 					   const std::vector<std::string>& args)
 {
 	(void)client;
@@ -117,7 +120,8 @@ ModeCommand::modeKeyOn(Client& client, Channel& chan,
 }
 
 void
-ModeCommand::modeKeyOff(Client& client, Channel& chan,
+ModeCommand::modeKeyOff(Client&							client,
+						Channel&						chan,
 						const std::vector<std::string>& args)
 {
 	(void)client;
@@ -128,14 +132,16 @@ ModeCommand::modeKeyOff(Client& client, Channel& chan,
 }
 
 void
-ModeCommand::modeOpOn(Client& client, Channel& chan,
-					  const std::vector<std::string>& args)
+ModeCommand::modeOpOn(
+	Client&	 client, // cppcheck-suppress constParameterCallback
+	Channel& chan,
+	const std::vector<std::string>& args)
 {
 	requireArgsNum(args, 3, "MODE #<channel> <othernick>");
 	requireWord(args, 2, "target nickname");
 	if (client.getNickname() != args[2])
 	{
-		Client* target = Server::getInstance()->getClientByNick(args[2]);
+		const Client* target = Server::getInstance()->getClientByNick(args[2]);
 		if (target)
 		{
 			if (!chan.isOperator(*target))
@@ -151,14 +157,16 @@ ModeCommand::modeOpOn(Client& client, Channel& chan,
 }
 
 void
-ModeCommand::modeOpOff(Client& client, Channel& chan,
-					   const std::vector<std::string>& args)
+ModeCommand::modeOpOff(
+	Client&	 client, // cppcheck-suppress constParameterCallback
+	Channel& chan,
+	const std::vector<std::string>& args)
 {
 	requireArgsNum(args, 3, "MODE #<channel> <othernick>");
 	requireWord(args, 2, "target nickname");
 	if (client.getNickname() != args[2])
 	{
-		Client* target = Server::getInstance()->getClientByNick(args[2]);
+		const Client* target = Server::getInstance()->getClientByNick(args[2]);
 		if (target)
 		{
 			if (chan.isOperator(*target))
@@ -174,7 +182,8 @@ ModeCommand::modeOpOff(Client& client, Channel& chan,
 }
 
 void
-ModeCommand::modeLimitOn(Client& client, Channel& chan,
+ModeCommand::modeLimitOn(Client&						 client,
+						 Channel&						 chan,
 						 const std::vector<std::string>& args)
 {
 	(void)client;
@@ -189,7 +198,8 @@ ModeCommand::modeLimitOn(Client& client, Channel& chan,
 }
 
 void
-ModeCommand::modeLimitOff(Client& client, Channel& chan,
+ModeCommand::modeLimitOff(Client&						  client,
+						  Channel&						  chan,
 						  const std::vector<std::string>& args)
 {
 	(void)client;


### PR DESCRIPTION
## Summary

Implements the channel-side MODE command by wiring `ModeCommand` into the
dispatcher, adding mutable channel mode state accessors, and replacing the
previous debug-only handler path with real channel state updates.

## What changed

### Command wiring
- registered `MODE` in `CommandDispatcher`

### Channel state API
- added setters/getters required by mode handlers:
  - `setUserLimit()`
  - `getInviteMode()` / `setInviteMode()`
  - `getTopicMode()` / `setTopicMode()`
  - `setKey()`

### Mode command
- defined `ModeCommand::NAME = "MODE"`
- changed `execute()` to receive `Client&`
- resolve the channel from the server before dispatching
- allow `MODE #channel` query path
- return `RPL_CHANNELMODEIS (324)` for mode queries
- enforce channel operator privileges with `ERR_CHANOPRIVSNEEDED (482)`
- return `ERR_NOSUCHCHANNEL (403)` when the target channel does not exist

### Implemented mode handlers
- `+i` / `-i`: toggle invite-only mode
- `+t` / `-t`: toggle topic restriction
- `+k` / `-k`: set/clear channel key
- `+o` / `-o`: grant/remove operator status
- `+l` / `-l`: set/clear user limit

### Validation and replies
- handlers use existing validators for channel, mode, nick, and positive ints
- missing target nick returns `ERR_NOSUCHNICK`
- mode query and change flow now go through IRC numerics instead of debug output

## Notes

This PR completes the core MODE execution path and replaces most of the
stub behaviour described in the issue with real mutations on `Channel`.
The handler map architecture remains unchanged.

## Protocol refs

- `MODE` channel command semantics from RFC 2812
- `RPL_CHANNELMODEIS (324)`
- `ERR_NOSUCHCHANNEL (403)`
- `ERR_CHANOPRIVSNEEDED (482)`